### PR TITLE
Responsive mint page

### DIFF
--- a/packages/components/ScreenContainer.tsx
+++ b/packages/components/ScreenContainer.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   SafeAreaView,
   ScrollView,
@@ -12,6 +12,7 @@ import {
 
 import { useMaxResolution } from "../hooks/useMaxResolution";
 import {
+  getResponsiveScreenContainerMarginHorizontal,
   headerHeight,
   headerMarginHorizontal,
   screenContainerContentMarginHorizontal,
@@ -32,6 +33,10 @@ export const ScreenContainer: React.FC<{
   noScroll?: boolean;
   fullWidth?: boolean;
   smallMargin?: boolean;
+  fixedFooterChildren?: React.ReactNode;
+  responsive?: boolean;
+  onBackPress?: () => void;
+  maxWidth?: number;
 }> = ({
   children,
   headerChildren,
@@ -43,15 +48,28 @@ export const ScreenContainer: React.FC<{
   fullWidth,
   smallMargin,
   customSidebar,
+  fixedFooterChildren,
+  responsive,
+  onBackPress,
+  maxWidth,
 }) => {
   // variables
   const { height } = useWindowDimensions();
   const hasMargin = !noMargin;
   const hasScroll = !noScroll;
+  const { width: screenWidth } = useMaxResolution({ responsive, noMargin });
+
+  const calculatedWidth = useMemo(
+    () => (maxWidth ? Math.min(maxWidth, screenWidth) : screenWidth),
+    [screenWidth, maxWidth]
+  );
+
   const marginStyle = hasMargin && {
-    marginHorizontal: screenContainerContentMarginHorizontal,
+    marginHorizontal: responsive
+      ? getResponsiveScreenContainerMarginHorizontal(calculatedWidth)
+      : screenContainerContentMarginHorizontal,
   };
-  const { width: maxWidth } = useMaxResolution();
+
   const width = fullWidth ? "100%" : maxWidth;
 
   // returns

--- a/packages/context/SidebarProvider.tsx
+++ b/packages/context/SidebarProvider.tsx
@@ -1,4 +1,6 @@
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useState, useEffect } from "react";
+import { useWindowDimensions } from "react-native";
+import { mobileWidth } from "../utils/style/layout";
 
 interface DefaultValue {
   isSidebarExpanded: boolean;
@@ -17,6 +19,14 @@ export const SidebarContextProvider: React.FC = ({ children }) => {
   const [isSidebarExpanded, setIsSidebarExpanded] = useState<boolean>(
     defaultValue.isSidebarExpanded
   );
+
+  const { width: windowWidth } = useWindowDimensions();
+
+  useEffect(() => {
+    setIsSidebarExpanded(
+      windowWidth >= mobileWidth ? defaultValue.isSidebarExpanded : false
+    );
+  }, [windowWidth]);
 
   const toggleSidebar = () => setIsSidebarExpanded(!isSidebarExpanded);
 

--- a/packages/hooks/useMaxResolution.ts
+++ b/packages/hooks/useMaxResolution.ts
@@ -4,22 +4,29 @@ import { useWindowDimensions } from "react-native";
 import { useSidebar } from "../context/SidebarProvider";
 import {
   fullSidebarWidth,
+  getResponsiveScreenContainerMarginHorizontal,
   headerHeight,
   screenContainerContentMarginHorizontal,
   screenContentMaxWidth,
   smallSidebarWidth,
 } from "../utils/style/layout";
 
-export const useMaxResolution = ({ noMargin = false } = {}) => {
+export const useMaxResolution = ({
+  noMargin = false,
+  responsive = true,
+} = {}) => {
   const { width: windowWidth, height } = useWindowDimensions();
   const { isSidebarExpanded } = useSidebar();
-  const width = useMemo(
-    () =>
-      windowWidth -
-      (isSidebarExpanded ? fullSidebarWidth : smallSidebarWidth) -
-      (noMargin ? 0 : screenContainerContentMarginHorizontal * 2),
-    [windowWidth, isSidebarExpanded]
-  );
+  const width = useMemo(() => {
+    const containerWidth =
+      windowWidth - (isSidebarExpanded ? fullSidebarWidth : smallSidebarWidth);
+    const responsiveMargin =
+      getResponsiveScreenContainerMarginHorizontal(containerWidth);
+    const defaultMargin = responsive
+      ? responsiveMargin
+      : screenContainerContentMarginHorizontal * 2;
+    return containerWidth - (noMargin ? 0 : defaultMargin);
+  }, [windowWidth, isSidebarExpanded]);
 
   return {
     width: width > screenContentMaxWidth ? screenContentMaxWidth : width,

--- a/packages/screens/Launchpad/MintCollectionScreen.tsx
+++ b/packages/screens/Launchpad/MintCollectionScreen.tsx
@@ -6,7 +6,7 @@ import {
   TextStyle,
   View,
   ViewStyle,
-  Dimensions,
+  useWindowDimensions,
 } from "react-native";
 import ConfettiCannon from "react-native-confetti-cannon";
 import CountDown from "react-native-countdown-component";
@@ -212,6 +212,8 @@ export const MintCollectionScreen: ScreenFC<"MintCollection"> = ({
     }
   }, [mintAddress]);
 
+  const { width } = useWindowDimensions();
+
   if (!info) {
     return <ScreenContainer noMargin />;
   }
@@ -222,8 +224,6 @@ export const MintCollectionScreen: ScreenFC<"MintCollection"> = ({
     website: websiteLink,
   } = info;
   const hasLinks = discordLink || twitterLink || websiteLink;
-
-  const windowWidth = Dimensions.get("window").width;
 
   if (notFound) {
     return (
@@ -239,7 +239,7 @@ export const MintCollectionScreen: ScreenFC<"MintCollection"> = ({
         <View
           style={{
             alignItems: "center",
-            width: windowWidth < 660 ? "90%" : "100%",
+            width: width < 660 ? "90%" : "100%",
             margin: "auto",
           }}
         >

--- a/packages/screens/Launchpad/MintCollectionScreen.tsx
+++ b/packages/screens/Launchpad/MintCollectionScreen.tsx
@@ -6,10 +6,10 @@ import {
   TextStyle,
   View,
   ViewStyle,
+  Dimensions,
 } from "react-native";
 import ConfettiCannon from "react-native-confetti-cannon";
 import CountDown from "react-native-countdown-component";
-import { Dimensions } from "react-native";
 
 import { BrandText } from "../../components/BrandText";
 import { ExternalLink } from "../../components/ExternalLink";
@@ -294,12 +294,14 @@ export const MintCollectionScreen: ScreenFC<"MintCollection"> = ({
                 </View>
               </View>
 
+              <View style={{ maxWidth: 420 }}>
               <GradientText
                 gradientType="grayLight"
-                style={[fontSemibold14, { marginBottom: 24, marginRight: 24 }]}
+                  style={[fontSemibold14, { marginBottom: 24 }]}
               >
                 {info.description}
               </GradientText>
+              </View>
 
               <ProgressionCard
                 label="Tokens Minted"

--- a/packages/screens/Launchpad/MintCollectionScreen.tsx
+++ b/packages/screens/Launchpad/MintCollectionScreen.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-native";
 import ConfettiCannon from "react-native-confetti-cannon";
 import CountDown from "react-native-countdown-component";
+import { Dimensions } from "react-native";
 
 import { BrandText } from "../../components/BrandText";
 import { ExternalLink } from "../../components/ExternalLink";
@@ -222,6 +223,8 @@ export const MintCollectionScreen: ScreenFC<"MintCollection"> = ({
   } = info;
   const hasLinks = discordLink || twitterLink || websiteLink;
 
+  const windowWidth = Dimensions.get("window").width;
+
   if (notFound) {
     return (
       <ScreenContainer noMargin>
@@ -233,7 +236,13 @@ export const MintCollectionScreen: ScreenFC<"MintCollection"> = ({
   } else
     return (
       <ScreenContainer noMargin fullWidth>
-        <View style={{ alignItems: "center" }}>
+        <View
+          style={{
+            alignItems: "center",
+            width: windowWidth < 660 ? "90%" : "100%",
+            margin: "auto",
+          }}
+        >
           <View
             style={{
               flexDirection: "row",

--- a/packages/screens/Mint/MintScreen.tsx
+++ b/packages/screens/Mint/MintScreen.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+import { ScreenContainer } from "../../components/ScreenContainer";
+import { BrandText } from "../../components/BrandText";
+
+export const MintScreen: React.FC = () => {
+  return (
+    <ScreenContainer>
+      <BrandText>Mint Screen Push</BrandText>
+    </ScreenContainer>
+  );
+};

--- a/packages/utils/style/layout.ts
+++ b/packages/utils/style/layout.ts
@@ -6,11 +6,24 @@ export const screenContentMaxWidth = 1092;
 export const screenContentMaxWidthLarge = 1290;
 export const headerMarginHorizontal = 22;
 export const avatarWidth = 40;
+export const mobileWidth = 768;
 export const walletSelectorWidth = 220;
 export const smallSidebarWidth = 76;
 export const fullSidebarWidth = 210;
 
 const BASE_SIZE = 8;
+
+export const getResponsiveScreenContainerMarginHorizontal = (width: number) => {
+  if (width >= 992) {
+    return 140;
+  } else if (width >= 768) {
+    return 80;
+  } else if (width >= 576) {
+    return 60;
+  } else {
+    return 15;
+  }
+};
 
 export const layout = {
   padding_x1: BASE_SIZE,


### PR DESCRIPTION
Responsive for below link:
Here is an example on TORI: https://app.teritori.com/collection/tori-tori1qdgvugdnscwnj8lc96q666000gyjv434kn9zl9ey3dph6p0cunusy6r42x/mint
Here an example on ETH: https://app.teritori.com/collection/eth-0x8f8304ea566affeb96ad0ffb593bbebd8876d124/mint