### PR TITLE
fix: add needed index to collection

### DIFF
--- a/go/internal/indexerdb/collection.go
+++ b/go/internal/indexerdb/collection.go
@@ -1,8 +1,9 @@
 package indexerdb
 
 import (
-	"github.com/TERITORI/teritori-dapp/go/pkg/networks"
 	"time"
+
+	"github.com/TERITORI/teritori-dapp/go/pkg/networks"
 )
 
 type Collection struct {
@@ -13,9 +14,9 @@ type Collection struct {
 	NetworkId           string
 	Name                string
 	ImageURI            string
-	MaxSupply           int
+	MaxSupply           int `gorm:"index"`
 	SecondaryDuringMint bool
-	Paused              bool
+	Paused              bool `gorm:"index"`
 	Time                time.Time
 
 	// "has one" relations


### PR DESCRIPTION
`max_supply` and `paused` are used in collections query without indexes
```
... where c.paused = false and c.max_supply != -1 and (select count from count_by_collection where collection_id = c.id) != c.max_supply
```