### PR TITLE
feat: use resizing image proxy for nfts and collections

### DIFF
--- a/.env
+++ b/.env
@@ -32,3 +32,6 @@ DISPLAYED_NETWORKS_IDS=teritori,teritori-testnet,ethereum,ethereum-goerli,cosmos
 SELECTABLE_NETWORKS_IDS=teritori,teritori-testnet,ethereum,ethereum-goerli,osmosis,osmosis-testnet
 
 PINATA_JWT=your_pinata_admin_jwt_key_here
+
+IMG_PROXY_URL=http://localhost:8080/insecure/
+IMGPROXY_ENABLE_WEBP_DETECTION=true

--- a/.env
+++ b/.env
@@ -33,5 +33,5 @@ SELECTABLE_NETWORKS_IDS=teritori,teritori-testnet,ethereum,ethereum-goerli,osmos
 
 PINATA_JWT=your_pinata_admin_jwt_key_here
 
-IMG_PROXY_URL=http://localhost:8080/insecure/
+IMG_PROXY_URL=https://imgproxy.mainnet.teritori.com/insecure/
 IMGPROXY_ENABLE_WEBP_DETECTION=true

--- a/mainnet.env
+++ b/mainnet.env
@@ -27,3 +27,4 @@ PRICES_SERVICE_URI=prices.mainnet.teritori.com:443
 
 DISPLAYED_NETWORKS_IDS=teritori,teritori-testnet,ethereum,ethereum-goerli,cosmos-hub,juno,osmosis,osmosis-testnet,solana
 SELECTABLE_NETWORKS_IDS=teritori,teritori-testnet,ethereum,ethereum-goerli,osmosis,osmosis-testnet
+IMG_PROXY_URL=https://imgproxy.mainnet.teritori.com/insecure/

--- a/packages/components/CollectionView.tsx
+++ b/packages/components/CollectionView.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from "react";
-import { Image, StyleSheet, Linking, View, Pressable } from "react-native";
+import { StyleSheet, Linking, View, Pressable } from "react-native";
 
 import { BrandText } from "./BrandText";
+import { OptimizedImage } from "./OptimizedImage";
 import { TertiaryBox } from "./boxes/TertiaryBox";
 import { GradientText } from "./gradientText";
 import { Collection, MintState } from "../api/marketplace/v1/marketplace";
@@ -51,8 +52,10 @@ export const CollectionView: React.FC<{
         width={sizedStyles.box.width}
         height={sizedStyles.box.height}
       >
-        <Image
+        <OptimizedImage
           source={{ uri: ipfsURLToHTTPURL(item.imageUri) }}
+          width={sizedStyles.image.width}
+          height={sizedStyles.image.height}
           style={{
             width: sizedStyles.image.width,
             height: sizedStyles.image.height,

--- a/packages/components/ImageWithTextInsert.tsx
+++ b/packages/components/ImageWithTextInsert.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { View, Image, ViewStyle, StyleProp } from "react-native";
+import { View, ViewStyle, StyleProp } from "react-native";
 
 import { BrandText } from "./BrandText";
+import { OptimizedImage } from "./OptimizedImage";
 
 export const ImageWithTextInsert: React.FC<{
   imageURL?: string;
@@ -12,7 +13,12 @@ export const ImageWithTextInsert: React.FC<{
   const padding = size * 0.045;
   return (
     <View style={[{ overflow: "hidden" }, style]}>
-      <Image source={{ uri: imageURL }} style={{ width: size, height: size }} />
+      <OptimizedImage
+        source={{ uri: imageURL }}
+        style={{ width: size, height: size }}
+        height={size}
+        width={size}
+      />
       {!!textInsert && (
         <BrandText
           style={{

--- a/packages/components/OptimizedImage.tsx
+++ b/packages/components/OptimizedImage.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Image, ImageStyle, ImageURISource, StyleProp } from "react-native";
+
+export const OptimizedImage: React.FC<{
+  source: ImageURISource;
+  width: number;
+  height: number;
+  style?: StyleProp<ImageStyle>;
+}> = ({ source, style, width, height }) => {
+  const params = resolveParams(width, height);
+  const uri = `${process.env.IMG_PROXY_URL}${params}/plain/${source.uri}`;
+  return <Image source={{ uri }} style={style} />;
+};
+
+const resolveParams = (width: number, height: number) => {
+  const params: string[] = [];
+  params.push(`width:${width}`);
+  params.push(`height:${height}`);
+
+  return params.join("/");
+};

--- a/packages/components/collections/CollectionInfoInline.tsx
+++ b/packages/components/collections/CollectionInfoInline.tsx
@@ -1,13 +1,14 @@
 import React from "react";
-import { Image, ImageSourcePropType, View } from "react-native";
+import { ImageURISource, View } from "react-native";
 
 import { fontSemibold14 } from "../../utils/style/fonts";
 import { layout } from "../../utils/style/layout";
 import { BrandText } from "../BrandText";
 import { OmniLink } from "../OmniLink";
+import { OptimizedImage } from "../OptimizedImage";
 
 export const CollectionInfoInline: React.FC<{
-  imageSource: ImageSourcePropType;
+  imageSource: ImageURISource;
   id?: string;
   name?: string;
 }> = ({ imageSource, id, name }) => {
@@ -19,9 +20,11 @@ export const CollectionInfoInline: React.FC<{
       }}
     >
       <View style={{ flexDirection: "row", alignItems: "center" }}>
-        <Image
+        <OptimizedImage
           source={imageSource}
           style={{ height: 32, width: 32, borderRadius: 999 }}
+          height={32}
+          width={32}
         />
         <BrandText
           style={[fontSemibold14, { marginLeft: layout.padding_x1_5 }]}


### PR DESCRIPTION
This is a placeholder with a demo and documentation on how to set up the proxy in our infrastructure.

Guide:

https://www.digitalocean.com/community/tutorials/how-to-serve-next-generation-images-with-imgproxy-using-docker

This is what I did to set it up locally (for testing, just for now).

```
docker pull darthsim/imgproxy:latest

Run it like this

docker run --env IMGPROXY_ENABLE_WEBP_DETECTION=true  -p 8080:8080 -it darthsim/imgproxy

```

I want to set up this properly on the cloud ☁️ that we have.

We can think of some suitable parameters.
The example provided used the value of the image and how big it is actually rendered by the browser to find a good initial step.