### PR TITLE
fix #525 Wallet page: Disconnect and rename button doesn't work

### DIFF
--- a/packages/screens/WalletManager/WalletItem.tsx
+++ b/packages/screens/WalletManager/WalletItem.tsx
@@ -17,6 +17,8 @@ import { SecondaryButton } from "../../components/buttons/SecondaryButton";
 import { useFeedbacks } from "../../context/FeedbacksProvider";
 import { rewardsPrice, TotalRewards, useRewards } from "../../hooks/useRewards";
 import { accountExplorerLink, getUserId } from "../../networks";
+import { setIsKeplrConnected } from "../../store/slices/settings";
+import { useAppDispatch } from "../../store/store";
 import { neutral33, neutral77 } from "../../utils/style/colors";
 
 export interface WalletItemProps {
@@ -37,6 +39,7 @@ export const WalletItem: React.FC<WalletItemProps> = ({
   item,
   itemsCount,
 }) => {
+  const dispatch = useAppDispatch();
   const { width } = useWindowDimensions();
   const { setToastSuccess } = useFeedbacks();
   const { claimAllRewards } = useRewards(
@@ -203,12 +206,10 @@ export const WalletItem: React.FC<WalletItemProps> = ({
               },
             },
             {
-              label: "Rename address",
-              onPress: () => {},
-            },
-            {
-              label: "Delete wallet",
-              onPress: () => {},
+              label: "Disconnect wallet",
+              onPress: () => {
+                dispatch(setIsKeplrConnected(false));
+              },
             },
           ]}
         />


### PR DESCRIPTION
## Notes:

- We don't have the notion of rename wallets
- also we don't allow to have more than one keplr wallet. (Keplr has it's own selector)
- I did a quick research and it can't be done.
- Implemented disconnect
- Deleted rename