### PR TITLE
fix: use grpc-web default transport for safari support

### DIFF
--- a/packages/utils/backend.ts
+++ b/packages/utils/backend.ts
@@ -26,7 +26,7 @@ export const getMarketplaceClient = (networkId: string | undefined) => {
   }
   if (!marketplaceClients[network.id]) {
     const rpc = new MarketplaceGrpcWebImpl(network.backendEndpoint, {
-      transport: grpc.WebsocketTransport(),
+      // transport: grpc.WebsocketTransport(),
       debug: false,
       // metadata: new grpc.Metadata({ SomeHeader: "bar" }),
     });


### PR DESCRIPTION
fix #556 

- I also tried to fix it via golang at gorilla (the lib) level.
- I also tried setting different values in the backend for the gRPC, but this is the only reliable way, I found, to do it.

## How to test

- Open the website in Safari (mobile and desktop).
- The sidebar and everything else should *NOW* work.
- Test other browsers for regressions.

## Important notes
- Needs this line commented out https://github.com/TERITORI/teritori-dapp/blob/8fba61e64cd92e1e7829d6fa4a0fd4d0f61d39b7/packages/context/SidebarProvider.tsx#L73 (addressed at #535 )
- I didn't try to send any tx using keplr.