### PR TITLE
fix: optimize leaderboard reset time to avoid corrupted staking situation

### DIFF
--- a/go/pkg/p2e/rewardutil.go
+++ b/go/pkg/p2e/rewardutil.go
@@ -55,11 +55,6 @@ func GetSeasonByTime(givenTime time.Time) (Season, float64, error) {
 	return Season{}, 0, errors.New("not in any season")
 }
 
-// returns: season, time passed in days, error
-func GetCurrentSeason() (Season, float64, error) {
-	return GetSeasonByTime(time.Now().UTC())
-}
-
 func GetSeasonById(seasonId string) (Season, error) {
 	for _, season := range GetAllSeasons() {
 		if seasonId == season.ID {

--- a/go/pkg/p2e/service.go
+++ b/go/pkg/p2e/service.go
@@ -2,6 +2,7 @@ package p2e
 
 import (
 	"context"
+	"time"
 
 	"github.com/TERITORI/teritori-dapp/go/internal/indexerdb"
 	"github.com/TERITORI/teritori-dapp/go/pkg/p2epb"
@@ -125,7 +126,8 @@ func (s *P2eService) Leaderboard(req *p2epb.LeaderboardRequest, srv p2epb.P2ESer
 }
 
 func (s *P2eService) CurrentSeason(ctx context.Context, req *p2epb.CurrentSeasonRequest) (*p2epb.CurrentSeasonResponse, error) {
-	currentSeason, remainingHp, err := GetCurrentSeason()
+	currentTime := time.Now().UTC()
+	currentSeason, remainingHp, err := GetSeasonByTime(currentTime)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get current season")
 	}


### PR DESCRIPTION
Description:
Currently, we reset the leaderboard at 23h59 so when user unstake between 23h59 - 00h00, his score will be taken into account in leaderboard which is unexpected behaviour.

Fix:
Now we reset leaderboard at 00h00, so all the calculation should be correct.