### PR TITLE
fix: cover image format at article creation

### DIFF
--- a/packages/components/fileUploader/FileUploader.tsx
+++ b/packages/components/fileUploader/FileUploader.tsx
@@ -20,11 +20,14 @@ import { PrimaryBox } from "../boxes/PrimaryBox";
 import { GradientText } from "../gradientText";
 import { Label } from "../inputs/TextInputCustom";
 
-const FILE_HEIGHT = 256;
-
 //FIXME: Doesn't work for now =>  Only the .web version is used
 
-export const FileUploader: React.FC<FileUploaderProps> = ({ label, style }) => {
+export const FileUploader: React.FC<FileUploaderProps> = ({
+  label,
+  style,
+  isImageCover,
+  fileHeight = 256,
+}) => {
   const [files, setFiles] = useState<File[] | FileList>([]);
 
   return (
@@ -38,7 +41,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({ label, style }) => {
             flexDirection: "row",
             alignItems: "center",
             justifyContent: "center",
-            height: files?.length ? FILE_HEIGHT : 80,
+            height: files?.length ? fileHeight : 80,
             borderRadius: 12,
           }}
         >
@@ -53,9 +56,12 @@ export const FileUploader: React.FC<FileUploaderProps> = ({ label, style }) => {
               />
               <Image
                 source={{ uri: files?.[0]?.path }}
-                style={{
-                  height: FILE_HEIGHT,
-                }}
+                style={[
+                  {
+                    height: fileHeight,
+                  },
+                  isImageCover && { width: "100%" },
+                ]}
               />
             </>
           ) : (
@@ -69,7 +75,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({ label, style }) => {
               ]}
               style={{ flex: 1 }}
               mainContainerStyle={{
-                height: files?.length ? FILE_HEIGHT : 80,
+                height: files?.length ? fileHeight : 80,
                 alignItems: "center",
                 padding: layout.padding_x2_5,
                 borderRadius: 12,

--- a/packages/components/fileUploader/FileUploader.type.ts
+++ b/packages/components/fileUploader/FileUploader.type.ts
@@ -1,12 +1,14 @@
 import React from "react";
-import { ViewStyle } from "react-native";
+import { StyleProp, ViewStyle } from "react-native";
 
 import { LocalFileData } from "../../utils/types/feed";
 
 export interface FileUploaderProps {
-  label?: string;
-  style?: ViewStyle;
   onUpload: (files: LocalFileData[]) => void;
+  label?: string;
+  style?: StyleProp<ViewStyle>;
+  isImageCover?: boolean;
+  fileHeight?: number;
   multiple?: boolean;
   mimeTypes?: string[];
   children?: ({ onPress }: { onPress: () => void }) => React.ReactNode;

--- a/packages/components/fileUploader/FileUploader.web.tsx
+++ b/packages/components/fileUploader/FileUploader.web.tsx
@@ -21,7 +21,6 @@ import { SVG } from "../SVG";
 import { PrimaryBox } from "../boxes/PrimaryBox";
 import { GradientText } from "../gradientText";
 import { Label } from "../inputs/TextInputCustom";
-const FILE_HEIGHT = 256;
 
 export const FileUploader: FC<FileUploaderProps> = ({
   label,
@@ -32,6 +31,8 @@ export const FileUploader: FC<FileUploaderProps> = ({
   mimeTypes,
   children,
   maxUpload,
+  isImageCover,
+  fileHeight = 256,
 }) => {
   const { setToastError } = useFeedbacks();
   const hiddenFileInput = useRef<HTMLInputElement>(null);
@@ -132,7 +133,7 @@ export const FileUploader: FC<FileUploaderProps> = ({
               flexDirection: "row",
               alignItems: "center",
               justifyContent: "center",
-              height: file ? FILE_HEIGHT : 80,
+              height: file ? fileHeight : 80,
               borderRadius: 12,
             }}
           >
@@ -149,9 +150,12 @@ export const FileUploader: FC<FileUploaderProps> = ({
                   src={file}
                   style={{
                     overflow: "hidden",
-                    height: FILE_HEIGHT,
+                    height: fileHeight,
                     backgroundSize: "cover",
+                    width: isImageCover ? "100%" : "auto",
+                    objectFit: isImageCover ? "cover" : "fill",
                   }}
+                  alt="Uploaded file"
                 />
               </>
             ) : (
@@ -165,7 +169,7 @@ export const FileUploader: FC<FileUploaderProps> = ({
                 ]}
                 style={{ flex: 1 }}
                 mainContainerStyle={{
-                  height: file ? FILE_HEIGHT : 80,
+                  height: file ? fileHeight : 80,
                   alignItems: "center",
                   padding: layout.padding_x2_5,
                   borderRadius: 12,

--- a/packages/components/socialFeed/SocialThread/ArticleRenderer.tsx
+++ b/packages/components/socialFeed/SocialThread/ArticleRenderer.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Image } from "react-native";
 
+import { ARTICLE_COVER_IMAGE_HEIGHT } from "../../../utils/social-feed";
 import { layout } from "../../../utils/style/layout";
 import { RemoteFileData } from "../../../utils/types/feed";
 import { BrandText } from "../../BrandText";
@@ -13,7 +14,7 @@ interface Props {
   audioFiles?: RemoteFileData[];
   isPreview?: boolean;
 }
-// TODO: Rework this ! Set a max height for preview
+
 export const ArticleRenderer: React.FC<Props> = ({
   metadata,
   audioFiles,
@@ -34,7 +35,7 @@ export const ArticleRenderer: React.FC<Props> = ({
           resizeMode="cover"
           style={{
             width: "100%",
-            height: 240,
+            height: ARTICLE_COVER_IMAGE_HEIGHT,
             marginBottom: layout.padding_x1_5,
           }}
         />

--- a/packages/screens/FeedNewArticle/FeedNewArticleScreen.tsx
+++ b/packages/screens/FeedNewArticle/FeedNewArticleScreen.tsx
@@ -33,7 +33,10 @@ import { getUserId, NetworkKind } from "../../networks";
 import { prettyPrice } from "../../utils/coins";
 import { IMAGE_MIME_TYPES } from "../../utils/mime";
 import { ScreenFC, useAppNavigation } from "../../utils/navigation";
-import { generateIpfsKey } from "../../utils/social-feed";
+import {
+  ARTICLE_COVER_IMAGE_HEIGHT,
+  generateIpfsKey,
+} from "../../utils/social-feed";
 import {
   neutral00,
   neutral11,
@@ -235,6 +238,8 @@ export const FeedNewArticleScreen: ScreenFC<"FeedNewArticle"> = () => {
 
         <FileUploader
           label="Cover image"
+          fileHeight={ARTICLE_COVER_IMAGE_HEIGHT}
+          isImageCover
           style={{
             marginTop: layout.padding_x3,
             width: "100%",

--- a/packages/utils/social-feed.ts
+++ b/packages/utils/social-feed.ts
@@ -15,6 +15,7 @@ export const DEFAULT_NAME = "Anon";
 export const DEFAULT_USERNAME = "anonymous";
 export const SOCIAL_FEED_ARTICLE_MIN_CHARS_LIMIT = 2500;
 export const NB_ROWS_SHOWN_IN_PREVIEW = 5;
+export const ARTICLE_COVER_IMAGE_HEIGHT = 240;
 
 export const getUpdatedReactions = (reactions: Reaction[], icon: string) => {
   const hasIcon = reactions.find((r) => r.icon === icon);


### PR DESCRIPTION
At the article creation, the cover image is now at the same format as the articles in the feed.
It prevent the misunderstanding "Why my image is not shown as in the creation (`/feed/new`)" ?