### PR TITLE
fix: optimize nfts list by memoizing NFTView

### DIFF
--- a/packages/components/collections/CollectionContent.tsx
+++ b/packages/components/collections/CollectionContent.tsx
@@ -7,7 +7,6 @@ import {
   Sort,
   SortDirection,
 } from "../../api/marketplace/v1/marketplace";
-import { useMaxResolution } from "../../hooks/useMaxResolution";
 import useSelectedWallet from "../../hooks/useSelectedWallet";
 import {
   selectAllSelectedAttributeDataByCollectionId,
@@ -15,11 +14,8 @@ import {
   selectPriceRange,
 } from "../../store/slices/marketplaceFilters";
 import { RootState } from "../../store/store";
-import { alignDown } from "../../utils/align";
 import { ActivityTable } from "../activity/ActivityTable";
 import { NFTs } from "../nfts/NFTs";
-
-const nftWidth = 268; // FIXME: ssot
 
 export const CollectionContent: React.FC<{
   id: string;
@@ -28,8 +24,6 @@ export const CollectionContent: React.FC<{
 }> = React.memo(({ id, selectedTab, sortDirection }) => {
   const wallet = useSelectedWallet();
 
-  const { width } = useMaxResolution({ isLarge: true });
-  const numColumns = Math.floor(width / nftWidth);
   const selectedFilters = useSelector((state: RootState) =>
     selectAllSelectedAttributeDataByCollectionId(state, id)
   );
@@ -39,7 +33,7 @@ export const CollectionContent: React.FC<{
   const nftsRequest: NFTsRequest = {
     collectionId: id,
     ownerId: (selectedTab === "owned" && wallet?.userId) || "",
-    limit: alignDown(20, numColumns) || numColumns,
+    limit: 100,
     offset: 0,
     sort: Sort.SORT_PRICE,
     sortDirection,

--- a/packages/components/nfts/NFTView.tsx
+++ b/packages/components/nfts/NFTView.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { memo, useRef, useState } from "react";
 import {
   ViewStyle,
   View,
@@ -54,7 +54,7 @@ import { SpacerColumn, SpacerRow } from "../spacer";
 export const NFTView: React.FC<{
   data: NFT;
   style?: StyleProp<ViewStyle>;
-}> = ({ data: nft, style }) => {
+}> = memo(({ data: nft, style }) => {
   const isMobile = useIsMobile();
   const cardWidth = isMobile ? 220 : 250;
   const { width: maxWidth } = useMaxResolution({ isLarge: true });
@@ -395,7 +395,7 @@ export const NFTView: React.FC<{
       />
     </>
   );
-};
+});
 
 const styles = StyleSheet.create({
   optionContainer: {

--- a/packages/components/nfts/NFTs.tsx
+++ b/packages/components/nfts/NFTs.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { FlatList, View } from "react-native";
 
 import { NFTView } from "./NFTView";
@@ -64,6 +64,12 @@ export const NFTs: React.FC<{
     fetchMore();
   }, [fetchMore]);
 
+  const nftViewStyle = useMemo(() => {
+    return {
+      width: elemSize,
+    };
+  }, [elemSize]);
+
   return (
     <View
       style={{
@@ -107,17 +113,12 @@ export const NFTs: React.FC<{
           data={padded}
           onEndReached={handleEndReached}
           keyExtractor={keyExtractor}
+          onEndReachedThreshold={4}
           ListEmptyComponent={
             <BrandText style={fontSemibold20}>No results found.</BrandText>
           }
           renderItem={(info) => (
-            <NFTView
-              key={info.item.mintAddress}
-              data={info.item}
-              style={{
-                width: elemSize,
-              }}
-            />
+            <NFTView key={info.item.id} data={info.item} style={nftViewStyle} />
           )}
         />
       </View>


### PR DESCRIPTION
Before this, scrolling the nfts list in collection screen can freeze a bit on my computer, with that it's smoooooth
this is not very scientific but the difference seems obvious

It memoize the NFTView and memoize it's style prop to make sure it doesn't get rerendered
Also it increase the onEndReachedThreshold and always fetch 100 nfts at a time