### PR TITLE
feat(sidebar): make "buy tokens" redirect to swap screen and enable "+" button

### DIFF
--- a/packages/components/navigation/BuyTokens.tsx
+++ b/packages/components/navigation/BuyTokens.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Linking, TextStyle, TouchableOpacity } from "react-native";
+import { TextStyle } from "react-native";
 import { CreditCardIcon } from "react-native-heroicons/outline";
 
 import { primaryColor } from "../../utils/style/colors";

--- a/packages/components/navigation/BuyTokens.tsx
+++ b/packages/components/navigation/BuyTokens.tsx
@@ -5,28 +5,29 @@ import { CreditCardIcon } from "react-native-heroicons/outline";
 import { primaryColor } from "../../utils/style/colors";
 import { layout } from "../../utils/style/layout";
 import { BrandText } from "../BrandText";
+import { OmniLink } from "../OmniLink";
 
 export const BuyTokens: React.FC<{
   flexDirection: "row" | "column";
   textStyle: TextStyle;
 }> = ({ flexDirection, textStyle }) => {
   return (
-    <TouchableOpacity
+    <OmniLink
+      to={{
+        screen: "Swap",
+      }}
       style={{
         justifyContent: "center",
         alignItems: "center",
         marginBottom: layout.spacing_x1,
         flexDirection,
       }}
-      onPress={() => {
-        Linking.openURL("https://frontier.osmosis.zone/?from=OSMO&to=TORI");
-      }}
     >
       <CreditCardIcon
         color={primaryColor}
         style={{ marginRight: flexDirection === "row" ? layout.spacing_x1 : 0 }}
       />
-      <BrandText style={textStyle}>Buy Tokens</BrandText>
-    </TouchableOpacity>
+      <BrandText style={textStyle}>Buy TORI</BrandText>
+    </OmniLink>
   );
 };

--- a/packages/components/navigation/Sidebar.tsx
+++ b/packages/components/navigation/Sidebar.tsx
@@ -136,11 +136,11 @@ export const Sidebar: React.FC = () => {
             <SidebarButton
               icon={addSVG}
               iconSize={36}
-              route="ComingSoon"
+              route="DAppStore"
               key="ComingSoon2"
               id="ComingSoon2"
               title=""
-              onPress={() => navigation.navigate("ComingSoon")}
+              onPress={() => navigation.navigate("DAppStore")}
             />
             <SpacerColumn size={1} />
           </>

--- a/packages/components/navigation/SidebarMobile.tsx
+++ b/packages/components/navigation/SidebarMobile.tsx
@@ -93,11 +93,11 @@ export const SidebarMobile: FC = () => {
             <SidebarButton
               icon={addSVG}
               iconSize={36}
-              route="ComingSoon"
+              route="DAppStore"
               key="ComingSoon2"
               id="ComingSoon2"
               title=""
-              onPress={() => navigation.navigate("ComingSoon")}
+              onPress={() => navigation.navigate("DAppStore")}
             />
             <SpacerColumn size={1} />
           </>


### PR DESCRIPTION
This is a suggestion, there are 2 changes.
1- Since Osmosis got rid of "frontier", we got a much worse user experience to onboard users. Specially buying their first tori.
This proposed change is leveraging the existing Swap feature, so people can use our UI to swap in osmosis.
2- when the users click on the + on the sidebar it will go to dapp store instead of showing coming soon
