### PR TITLE
fix: upgrade docker go version

### DIFF
--- a/go/cmd/feed-clean-pinata-keys/Dockerfile
+++ b/go/cmd/feed-clean-pinata-keys/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.18"
+ARG GO_VERSION="1.19"
 ARG RUNNER_IMAGE="gcr.io/distroless/static"
 
 # --------------------------------------------------------

--- a/go/cmd/multisig-backend/Dockerfile
+++ b/go/cmd/multisig-backend/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.18"
+ARG GO_VERSION="1.19"
 ARG RUNNER_IMAGE="gcr.io/distroless/static"
 
 # --------------------------------------------------------

--- a/go/cmd/p2e-update-leaderboard/Dockerfile
+++ b/go/cmd/p2e-update-leaderboard/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.18"
+ARG GO_VERSION="1.19"
 ARG RUNNER_IMAGE="gcr.io/distroless/static"
 
 # --------------------------------------------------------

--- a/go/cmd/prices-ohlc-refresh/Dockerfile
+++ b/go/cmd/prices-ohlc-refresh/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.18"
+ARG GO_VERSION="1.19"
 ARG RUNNER_IMAGE="gcr.io/distroless/static"
 
 # --------------------------------------------------------

--- a/go/cmd/prices-service/Dockerfile
+++ b/go/cmd/prices-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.18"
+ARG GO_VERSION="1.19"
 ARG RUNNER_IMAGE="gcr.io/distroless/static"
 
 # --------------------------------------------------------

--- a/go/cmd/teritori-dapp-backend/Dockerfile
+++ b/go/cmd/teritori-dapp-backend/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.18"
+ARG GO_VERSION="1.19"
 ARG RUNNER_IMAGE="gcr.io/distroless/static"
 
 # --------------------------------------------------------

--- a/go/cmd/teritori-indexer/Dockerfile
+++ b/go/cmd/teritori-indexer/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.18"
+ARG GO_VERSION="1.19"
 ARG RUNNER_IMAGE="gcr.io/distroless/static"
 
 # --------------------------------------------------------


### PR DESCRIPTION
we can't build the dockers image since some pakage upgrade that probably happened in wesh PRs requires go >= 1.19