### PR TITLE
fix(feed): fix query in user feed

### DIFF
--- a/go/pkg/feed/service.go
+++ b/go/pkg/feed/service.go
@@ -116,7 +116,7 @@ func (s *FeedService) Posts(ctx context.Context, req *feedpb.PostsRequest) (*fee
 		query = query.Where("category IN ?", categories)
 	}
 	if user != "" {
-		query = query.Where("created_by = ?", user)
+		query = query.Where("author_id = ?", user)
 	}
 	if len(hashtags) > 0 {
 		formattedHashtags := make([]string, 0)


### PR DESCRIPTION
- Fixed query parameter name from "created_by" to "author_id" in the feed service.go file.
- This fixes an issue where the wrong query parameter was being used.
- The issue number is hotfix/profile-posts-not-working.