### PR TITLE
chore: refactor core box components

### DIFF
--- a/packages/components/CollectionView.tsx
+++ b/packages/components/CollectionView.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, Linking, View, Pressable } from "react-native";
 
 import { BrandText } from "./BrandText";
 import { OptimizedImage } from "./OptimizedImage";
-import { TertiaryBox } from "./boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "./boxes/LegacyTertiaryBox";
 import { GradientText } from "./gradientText";
 import { Collection, MintState } from "../api/marketplace/v1/marketplace";
 import { useCollectionThumbnailInfo } from "../hooks/collection/useCollectionThumbnailInfo";
@@ -45,7 +45,7 @@ export const CollectionView: React.FC<{
       }}
       disabled={item.id === "" && item.twitterUrl === ""}
     >
-      <TertiaryBox
+      <LegacyTertiaryBox
         noBrokenCorners={size === "XS"}
         mainContainerStyle={sizedStyles.boxMainContainer}
         width={sizedStyles.box.width}
@@ -139,7 +139,7 @@ export const CollectionView: React.FC<{
             )}
           </View>
         </View>
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </Pressable>
   );
 };

--- a/packages/components/CopyToClipboard.tsx
+++ b/packages/components/CopyToClipboard.tsx
@@ -4,7 +4,7 @@ import { TouchableOpacity } from "react-native";
 
 import { BrandText } from "./BrandText";
 import { SVG } from "./SVG";
-import { TertiaryBox } from "./boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "./boxes/LegacyTertiaryBox";
 import copySVG from "../../assets/icons/copy.svg";
 import { useFeedbacks } from "../context/FeedbacksProvider";
 import { neutral22 } from "../utils/style/colors";
@@ -32,7 +32,7 @@ export const CopyToClipboard: React.FC<{
 
   return (
     <TouchableOpacity onPress={() => copyToClipboard(text)}>
-      <TertiaryBox
+      <LegacyTertiaryBox
         height={40}
         width={fullWidth ? undefined : 332}
         fullWidth={fullWidth}
@@ -55,7 +55,7 @@ export const CopyToClipboard: React.FC<{
           source={copySVG}
           style={{ marginRight: 12, marginLeft: 8 }}
         />
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/CopyToClipboardIcon.tsx
+++ b/packages/components/CopyToClipboardIcon.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { TouchableOpacity } from "react-native";
 
 import { SVG } from "./SVG";
-import { TertiaryBox } from "./boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "./boxes/LegacyTertiaryBox";
 import copySVG from "../../assets/icons/copy.svg";
 import { useFeedbacks } from "../context/FeedbacksProvider";
 import { neutral22 } from "../utils/style/colors";
@@ -27,7 +27,7 @@ export const CopyToClipboardIcon: React.FC<{
 
   return (
     <TouchableOpacity onPress={copyToClipboard}>
-      <TertiaryBox
+      <LegacyTertiaryBox
         height={size}
         width={size}
         mainContainerStyle={{
@@ -37,7 +37,7 @@ export const CopyToClipboardIcon: React.FC<{
         squaresBackgroundColor={squaresBackgroundColor}
       >
         <SVG width={iconSize} height={iconSize} source={copySVG} />
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/CopyToClipboardSecondary.tsx
+++ b/packages/components/CopyToClipboardSecondary.tsx
@@ -6,7 +6,7 @@ import { BrandText } from "./BrandText";
 import { useCopyToClipboard } from "./CopyToClipboard";
 import { NetworkIcon } from "./NetworkIcon";
 import { SVG } from "./SVG";
-import { TertiaryBox } from "./boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "./boxes/LegacyTertiaryBox";
 import copySVG from "../../assets/icons/copy.svg";
 import { fontMedium14 } from "../utils/style/fonts";
 import { layout } from "../utils/style/layout";
@@ -21,7 +21,7 @@ export const CopyToClipboardSecondary: React.FC<{
 
   return (
     <TouchableOpacity onPress={() => copyToClipboard(text)}>
-      <TertiaryBox
+      <LegacyTertiaryBox
         height={40}
         width={216}
         mainContainerStyle={{
@@ -42,7 +42,7 @@ export const CopyToClipboardSecondary: React.FC<{
           {displayedText}
         </BrandText>
         <SVG width={16} height={16} source={copySVG} />
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/GovernanceBox/GovernanceBox.tsx
+++ b/packages/components/GovernanceBox/GovernanceBox.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-native";
 
 import { BrandText } from "../../components/BrandText/BrandText";
-import { TertiaryBox } from "../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../components/boxes/LegacyTertiaryBox";
 import { ProposalStatus } from "../../screens/Governance/types";
 import { tulipTree } from "../../utils/style/colors";
 
@@ -129,7 +129,7 @@ export const GovernanceBox: React.FC<{
       >
         {activeGovernanceDetailsPopup()}
 
-        <TertiaryBox width={600} height={300}>
+        <LegacyTertiaryBox width={600} height={300}>
           <View
             style={{
               flexDirection: "column",
@@ -393,7 +393,7 @@ export const GovernanceBox: React.FC<{
               </View>
             </View>
           </View>
-        </TertiaryBox>
+        </LegacyTertiaryBox>
       </TouchableOpacity>
     </View>
   );

--- a/packages/components/Menu.tsx
+++ b/packages/components/Menu.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from "react";
 import { View, TouchableOpacity } from "react-native";
 
 import { BrandText } from "./BrandText";
-import { PrimaryBox } from "./boxes/PrimaryBox";
+import { LegacyPrimaryBox } from "./boxes/LegacyPrimaryBox";
 import { useDropdowns } from "../context/DropdownsProvider";
 import { neutral33 } from "../utils/style/colors";
 import { fontSemibold13 } from "../utils/style/fonts";
@@ -36,7 +36,7 @@ export const Menu: React.FC<MenuProps> = ({
       </TouchableOpacity>
       {isDropdownOpen(dropdownRef) && (
         <View ref={dropdownRef}>
-          <PrimaryBox
+          <LegacyPrimaryBox
             width={width}
             style={{ position: "absolute", right: 0, bottom: -20 }}
             mainContainerStyle={{
@@ -68,7 +68,7 @@ export const Menu: React.FC<MenuProps> = ({
                 </BrandText>
               </TouchableOpacity>
             ))}
-          </PrimaryBox>
+          </LegacyPrimaryBox>
         </View>
       )}
     </View>

--- a/packages/components/NetworkSelector/NetworkSelector.tsx
+++ b/packages/components/NetworkSelector/NetworkSelector.tsx
@@ -29,12 +29,13 @@ export const NetworkSelector: React.FC<{
     <View style={style} ref={dropdownRef}>
       <TouchableOpacity onPress={() => onPressDropdownButton(dropdownRef)}>
         <TertiaryBox
-          mainContainerStyle={{
+          style={{
             flexDirection: "row",
             paddingHorizontal: 12,
             backgroundColor: neutral17,
+            alignItems: "center",
+            height: 40,
           }}
-          height={40}
         >
           <NetworkIcon networkId={selectedNetworkInfo?.id || ""} size={16} />
           <SpacerRow size={1} />

--- a/packages/components/NetworkSelector/NetworkSelectorMenu.tsx
+++ b/packages/components/NetworkSelector/NetworkSelectorMenu.tsx
@@ -20,7 +20,7 @@ import { layout } from "../../utils/style/layout";
 import { WalletProvider } from "../../utils/walletProvider";
 import { BrandText } from "../BrandText";
 import { NetworkIcon } from "../NetworkIcon";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { TertiaryButton } from "../buttons/TertiaryButton";
 import { NetworksListModal } from "../modals/NetworksListModal";
 
@@ -75,7 +75,7 @@ export const NetworkSelectorMenu: FC<{
   };
 
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       width={172}
       noBrokenCorners
       style={style}
@@ -145,6 +145,6 @@ export const NetworkSelectorMenu: FC<{
           setNetworksModalVisible(false);
         }}
       />
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };

--- a/packages/components/NetworkSelector/NetworkSelectorMobile.tsx
+++ b/packages/components/NetworkSelector/NetworkSelectorMobile.tsx
@@ -11,7 +11,7 @@ import { secondaryColor } from "../../utils/style/colors";
 import { layout } from "../../utils/style/layout";
 import { NetworkIcon } from "../NetworkIcon";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { SpacerRow } from "../spacer";
 
 export const NetworkSelectorMobile: React.FC<{
@@ -27,7 +27,7 @@ export const NetworkSelectorMobile: React.FC<{
   return (
     <View style={style} ref={dropdownRef}>
       <TouchableOpacity onPress={() => onPressDropdownButton(dropdownRef)}>
-        <TertiaryBox
+        <LegacyTertiaryBox
           noBrokenCorners
           mainContainerStyle={{
             flexDirection: "row",
@@ -43,7 +43,7 @@ export const NetworkSelectorMobile: React.FC<{
             height={16}
             color={secondaryColor}
           />
-        </TertiaryBox>
+        </LegacyTertiaryBox>
       </TouchableOpacity>
 
       {isDropdownOpen(dropdownRef) && (

--- a/packages/components/Pagination.tsx
+++ b/packages/components/Pagination.tsx
@@ -3,8 +3,8 @@ import { StyleSheet, TouchableOpacity, View } from "react-native";
 
 import { BrandText } from "./BrandText";
 import { SVG } from "./SVG";
-import { SecondaryBox } from "./boxes/SecondaryBox";
-import { TertiaryBox } from "./boxes/TertiaryBox";
+import { LegacySecondaryBox } from "./boxes/LegacySecondaryBox";
+import { LegacyTertiaryBox } from "./boxes/LegacyTertiaryBox";
 import { SpacerRow } from "./spacer";
 import chevronDownSVG from "../../assets/icons/chevron-down.svg";
 import chevronLeftDoubleSVG from "../../assets/icons/chevron-left-double.svg";
@@ -63,32 +63,32 @@ export const Pagination = ({
 
       <View style={styles.section}>
         <TouchableOpacity onPress={() => handleChangePage(0)}>
-          <TertiaryBox height={42} width={56}>
+          <LegacyTertiaryBox height={42} width={56}>
             <SVG source={chevronLeftDoubleSVG} height={16} width={16} />
-          </TertiaryBox>
+          </LegacyTertiaryBox>
         </TouchableOpacity>
         <SpacerRow size={1} />
         <TouchableOpacity onPress={() => handleChangePage(currentPage - 1)}>
-          <TertiaryBox height={42} width={56}>
+          <LegacyTertiaryBox height={42} width={56}>
             <SVG source={chevronLeftSVG} height={16} width={16} />
-          </TertiaryBox>
+          </LegacyTertiaryBox>
         </TouchableOpacity>
         <SpacerRow size={2} />
         <TouchableOpacity onPress={() => handleChangePage(currentPage + 1)}>
-          <TertiaryBox height={42} width={56}>
+          <LegacyTertiaryBox height={42} width={56}>
             <SVG source={chevronRightSVG} height={16} width={16} />
-          </TertiaryBox>
+          </LegacyTertiaryBox>
         </TouchableOpacity>
         <SpacerRow size={1} />
         <TouchableOpacity onPress={() => handleChangePage(maxPage - 1)}>
-          <TertiaryBox height={42} width={56}>
+          <LegacyTertiaryBox height={42} width={56}>
             <SVG source={chevronRightDoubleSVG} height={16} width={16} />
-          </TertiaryBox>
+          </LegacyTertiaryBox>
         </TouchableOpacity>
       </View>
 
       <View style={[styles.section, { justifyContent: "flex-end" }]}>
-        <TertiaryBox height={42} width={80}>
+        <LegacyTertiaryBox height={42} width={80}>
           <TouchableOpacity
             style={{
               flexDirection: "row",
@@ -111,10 +111,10 @@ export const Pagination = ({
               color={secondaryColor}
             />
           </TouchableOpacity>
-        </TertiaryBox>
+        </LegacyTertiaryBox>
 
         {isDropdownOpen(dropdownRef) && (
-          <SecondaryBox
+          <LegacySecondaryBox
             noBrokenCorners
             width={80}
             style={{ position: "absolute", top: 46, right: 0 }}
@@ -147,7 +147,7 @@ export const Pagination = ({
                 </BrandText>
               </TouchableOpacity>
             ))}
-          </SecondaryBox>
+          </LegacySecondaryBox>
         )}
       </View>
     </View>

--- a/packages/components/Search/SearchBar.tsx
+++ b/packages/components/Search/SearchBar.tsx
@@ -13,7 +13,7 @@ import {
 import { useDropdowns } from "../../context/DropdownsProvider";
 import { useSearchBar } from "../../context/SearchBarProvider";
 import { COLLECTION_VIEW_SM_WIDTH } from "../CollectionView";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 export const SearchBar: React.FC<{ style?: StyleProp<ViewStyle> }> = ({
   style,
@@ -30,7 +30,7 @@ export const SearchBar: React.FC<{ style?: StyleProp<ViewStyle> }> = ({
     >
       <SearchBarInputGlobal onInteraction={() => openDropdown(dropdownRef)} />
       {isDropdownOpen(dropdownRef) && hasSomething && (
-        <TertiaryBox
+        <LegacyTertiaryBox
           noBrokenCorners
           style={{
             position: "absolute",
@@ -47,7 +47,7 @@ export const SearchBar: React.FC<{ style?: StyleProp<ViewStyle> }> = ({
           }}
         >
           <SearchBarResults />
-        </TertiaryBox>
+        </LegacyTertiaryBox>
       )}
     </View>
   );

--- a/packages/components/Search/SearchBarInput.tsx
+++ b/packages/components/Search/SearchBarInput.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { StyleProp, TextInput, ViewStyle, StyleSheet } from "react-native";
+import { StyleProp, TextInput, StyleSheet } from "react-native";
 import { useSelector } from "react-redux";
 
 import searchSVG from "../../../assets/icons/search.svg";
@@ -8,13 +8,14 @@ import { useAppDispatch } from "../../store/store";
 import { neutral17 } from "../../utils/style/colors";
 import { fontSemibold14 } from "../../utils/style/fonts";
 import { SVG } from "../SVG";
+import { BoxStyle } from "../boxes/Box";
 import { TertiaryBox } from "../boxes/TertiaryBox";
 
 export const SEARCH_BAR_INPUT_HEIGHT = 40;
 
 export const SearchBarInputGlobal: React.FC<{
   onInteraction?: () => void;
-  style?: StyleProp<ViewStyle>;
+  style?: StyleProp<BoxStyle>;
 }> = (props) => {
   const text = useSelector(selectSearchText);
   const dispatch = useAppDispatch();
@@ -31,21 +32,23 @@ export const SearchBarInput: React.FC<{
   text: string;
   onChangeText: (text: string) => void;
   onInteraction?: () => void;
-  style?: StyleProp<ViewStyle>;
+  style?: StyleProp<BoxStyle>;
 }> = ({ onInteraction, text, onChangeText, style }) => {
   const ref = useRef<TextInput>(null);
   const fullWidth = StyleSheet.flatten(style)?.width === "100%";
   return (
     <TertiaryBox
-      style={style}
-      mainContainerStyle={{
-        flexDirection: "row",
-        paddingHorizontal: 12,
-        backgroundColor: neutral17,
-        width: fullWidth ? undefined : 250,
-      }}
-      fullWidth={fullWidth}
-      height={SEARCH_BAR_INPUT_HEIGHT}
+      style={[
+        {
+          flexDirection: "row",
+          paddingHorizontal: 12,
+          backgroundColor: neutral17,
+          width: fullWidth ? "100%" : 250,
+          height: SEARCH_BAR_INPUT_HEIGHT,
+          alignItems: "center",
+        },
+        style,
+      ]}
     >
       <SVG source={searchSVG} width={16} height={16} />
       <TextInput

--- a/packages/components/Search/SearchButtonMobile.tsx
+++ b/packages/components/Search/SearchButtonMobile.tsx
@@ -5,13 +5,13 @@ import searchSVG from "../../../assets/icons/search.svg";
 import { useSearchBar } from "../../context/SearchBarProvider";
 import { layout } from "../../utils/style/layout";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 export const SearchButtonMobile: React.FC = () => {
   const { setSearchModalMobileOpen } = useSearchBar();
   return (
     <TouchableOpacity onPress={() => setSearchModalMobileOpen(true)}>
-      <TertiaryBox
+      <LegacyTertiaryBox
         noBrokenCorners
         mainContainerStyle={{
           flexDirection: "row",
@@ -21,7 +21,7 @@ export const SearchButtonMobile: React.FC = () => {
         width={32}
       >
         <SVG source={searchSVG} width={16} height={16} />
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/Search/SearchModalMobile.tsx
+++ b/packages/components/Search/SearchModalMobile.tsx
@@ -14,7 +14,6 @@ export const SearchModalMobile: FC<{
     <ModalBase
       scrollable
       verticalPosition="top"
-      noBrokenCorners
       visible={visible}
       onClose={onClose}
       width={windowWidth}

--- a/packages/components/TopMenu/TopMenu.tsx
+++ b/packages/components/TopMenu/TopMenu.tsx
@@ -15,7 +15,7 @@ import {
 } from "../../utils/style/colors";
 import { fontSemibold14 } from "../../utils/style/fonts";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 export const TOP_MENU_BUTTON_HEIGHT = 40;
 
@@ -27,7 +27,7 @@ export const TopMenu: FC = () => {
   return (
     <View ref={dropdownRef}>
       <TouchableOpacity onPress={() => onPressDropdownButton(dropdownRef)}>
-        <TertiaryBox
+        <LegacyTertiaryBox
           width={220}
           mainContainerStyle={[
             styles.buttonBoxMainContainer,
@@ -46,7 +46,7 @@ export const TopMenu: FC = () => {
             height={16}
             color={secondaryColor}
           />
-        </TertiaryBox>
+        </LegacyTertiaryBox>
       </TouchableOpacity>
 
       <TopMenuBox

--- a/packages/components/TopMenu/TopMenuBox.tsx
+++ b/packages/components/TopMenu/TopMenuBox.tsx
@@ -19,7 +19,7 @@ import { headerHeight, layout, topMenuWidth } from "../../utils/style/layout";
 import { BrandText } from "../BrandText";
 import FlexCol from "../FlexCol";
 import { OmniLink } from "../OmniLink";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { Separator } from "../separators/Separator";
 
 export const TopMenuBox: FC<{
@@ -29,7 +29,7 @@ export const TopMenuBox: FC<{
   const { height: windowHeight } = useWindowDimensions();
 
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       width={topMenuWidth}
       noBrokenCorners
       style={[style, { borderRadius: 8 }]}
@@ -57,7 +57,7 @@ export const TopMenuBox: FC<{
           </FlexCol>
         </OmniLink>
       </ScrollView>
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };
 

--- a/packages/components/TopMenu/TopMenuHighlightedNews.tsx
+++ b/packages/components/TopMenu/TopMenuHighlightedNews.tsx
@@ -18,7 +18,7 @@ export const TopMenuHighlightedNews: React.FC = () => {
     <TopMenuSection title="Highlighted News">
       <FlexCol>
         <Link to={banner?.url || ""}>
-          <PrimaryBox noBrokenCorners>
+          <PrimaryBox>
             <Image
               source={{
                 uri: ipfsURLToHTTPURL(banner?.image),

--- a/packages/components/TopMenu/TopMenuMyTeritories.tsx
+++ b/packages/components/TopMenu/TopMenuMyTeritories.tsx
@@ -11,7 +11,7 @@ import { BrandText } from "../BrandText";
 import FlexCol from "../FlexCol";
 import FlexRow from "../FlexRow";
 import { OmniLink } from "../OmniLink";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { SmallCarousel } from "../carousels/SmallCarousel";
 import { UserAvatarWithFrame } from "../images/AvatarWithFrame";
 
@@ -23,7 +23,7 @@ const OrgCard: React.FC<{ organization: DAO }> = ({ organization }) => {
     <OmniLink
       to={{ screen: "UserPublicProfile", params: { id: organization.id } }}
     >
-      <TertiaryBox
+      <LegacyTertiaryBox
         height={48}
         width={ORG_CARD_WIDTH}
         mainContainerStyle={{
@@ -53,7 +53,7 @@ const OrgCard: React.FC<{ organization: DAO }> = ({ organization }) => {
             </BrandText>
           </FlexCol>
         </FlexRow>
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </OmniLink>
   );
 };

--- a/packages/components/WalletStatusBox.tsx
+++ b/packages/components/WalletStatusBox.tsx
@@ -4,7 +4,7 @@ import { View, useWindowDimensions } from "react-native";
 import { BrandText } from "./BrandText";
 import { NetworkIcon } from "./NetworkIcon";
 import { SuccessBadge } from "./badges/SuccessBadge";
-import { TertiaryBox } from "./boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "./boxes/LegacyTertiaryBox";
 import { useSelectedNetworkInfo } from "../hooks/useSelectedNetwork";
 import useSelectedWallet from "../hooks/useSelectedWallet";
 import { neutral11, neutral77 } from "../utils/style/colors";
@@ -22,7 +22,7 @@ export const WalletStatusBox: React.FC = () => {
   const selectedNetworkInfo = useSelectedNetworkInfo();
 
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       fullWidth
       mainContainerStyle={{
         paddingVertical: layout.spacing_x1,
@@ -60,6 +60,6 @@ export const WalletStatusBox: React.FC = () => {
       ) : (
         <BrandText style={fontSemibold14}>Wallet is not connected</BrandText>
       )}
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };

--- a/packages/components/boxes/Box.tsx
+++ b/packages/components/boxes/Box.tsx
@@ -1,0 +1,319 @@
+import { LinearGradient, LinearGradientProps } from "expo-linear-gradient";
+import { ReactNode } from "react";
+import {
+  StyleProp,
+  View,
+  ViewStyle,
+  StyleSheet,
+  ViewProps,
+} from "react-native";
+
+import { useTheme } from "../../hooks/useTheme";
+
+// Be very careful while editing this, try to refrain from adding new props
+
+const defaultBoxBorderRadius = 8;
+const notchRadius = 12;
+
+export type BoxStyle = Pick<
+  ViewStyle,
+  | "margin"
+  | "marginBottom"
+  | "marginEnd"
+  | "marginHorizontal"
+  | "marginLeft"
+  | "marginRight"
+  | "marginStart"
+  | "marginTop"
+  | "marginVertical"
+  | "width"
+  | "height"
+  | "borderWidth"
+  | "padding"
+  | "paddingBottom"
+  | "paddingEnd"
+  | "paddingHorizontal"
+  | "paddingLeft"
+  | "paddingRight"
+  | "paddingStart"
+  | "paddingTop"
+  | "paddingVertical"
+  | "alignItems"
+  | "justifyContent"
+  | "flexDirection"
+  | "minWidth"
+  | "maxWidth"
+  | "minHeight"
+  | "maxHeight"
+  | "alignSelf"
+  | "opacity"
+  | "position"
+  | "left"
+  | "right"
+  | "top"
+  | "bottom"
+  | "flex"
+> & { borderRadius?: number; backgroundColor?: string; borderColor?: string };
+
+export type GradientParams = Omit<LinearGradientProps, keyof ViewProps>;
+
+export const Box: React.FC<{
+  children: ReactNode;
+  borderGradient?: GradientParams;
+  fillGradient?: GradientParams;
+  notched?: boolean;
+  style?: StyleProp<BoxStyle>;
+}> = ({
+  children,
+  borderGradient: maybeBorderProps,
+  fillGradient: maybeFillProps,
+  notched,
+  style,
+}) => {
+  const theme = useTheme();
+  const flatStyle = StyleSheet.flatten(style);
+  const {
+    margin,
+    width,
+    height,
+    borderWidth: maybeBorderWidth,
+    borderRadius: maybeBorderRadius,
+    backgroundColor,
+    borderColor,
+    marginBottom,
+    marginEnd,
+    marginHorizontal,
+    marginLeft,
+    marginRight,
+    marginStart,
+    marginTop,
+    marginVertical,
+    minWidth,
+    maxWidth,
+    minHeight,
+    maxHeight,
+    alignSelf,
+    opacity,
+    position,
+    left,
+    right,
+    top,
+    bottom,
+    flex,
+    ...styleRest
+  } = flatStyle;
+
+  const borderWidth = maybeBorderWidth === undefined ? 0 : maybeBorderWidth;
+  const borderRadius =
+    maybeBorderRadius === undefined
+      ? defaultBoxBorderRadius
+      : maybeBorderRadius;
+
+  const fillProps = maybeFillProps || {
+    colors: [theme.backgroundColor, theme.backgroundColor],
+  };
+  const borderProps = maybeBorderProps || {
+    colors: [theme.backgroundColor, theme.backgroundColor],
+  };
+  let { colors: borderColors, ...borderPropsRest } = borderProps;
+  if (borderColor) {
+    borderColors = [borderColor, borderColor];
+  }
+  let { colors: fillColors, ...fillPropsRest } = fillProps;
+  if (backgroundColor) {
+    fillColors = [backgroundColor, backgroundColor];
+  }
+  return (
+    <View
+      style={{
+        margin,
+        marginBottom,
+        marginEnd,
+        marginHorizontal,
+        marginLeft,
+        marginRight,
+        marginStart,
+        marginTop,
+        marginVertical,
+        minWidth,
+        maxWidth,
+        minHeight,
+        maxHeight,
+        width,
+        height,
+        alignSelf,
+        opacity,
+        position,
+        left,
+        right,
+        top,
+        bottom,
+        flex,
+      }}
+    >
+      {borderWidth > 0 &&
+        (notched ? (
+          <NotchedRectangle
+            style={{
+              width: "100%",
+              height: "100%",
+              position: "absolute",
+              borderRadius,
+            }}
+            notchRadius={notchRadius}
+            color={borderColors[0]}
+          />
+        ) : (
+          <LinearGradient
+            style={{
+              width: "100%",
+              height: "100%",
+              position: "absolute",
+              borderRadius,
+            }}
+            colors={borderColors}
+            {...borderPropsRest}
+          />
+        ))}
+      {notched ? (
+        <NotchedRectangle
+          style={{
+            left: borderWidth,
+            top: borderWidth,
+            right: borderWidth,
+            bottom: borderWidth,
+            position: "absolute",
+            borderRadius: borderRadius ? borderRadius - borderWidth : undefined,
+          }}
+          notchRadius={notchRadius - borderWidth / 2}
+          color={fillColors[0]}
+        />
+      ) : (
+        <LinearGradient
+          style={{
+            left: borderWidth,
+            top: borderWidth,
+            right: borderWidth,
+            bottom: borderWidth,
+            position: "absolute",
+            borderRadius: borderRadius ? borderRadius - borderWidth : undefined,
+          }}
+          colors={fillColors}
+          {...fillPropsRest}
+        />
+      )}
+      <View
+        style={[
+          {
+            width: "100%",
+            height: "100%",
+            borderWidth,
+            borderColor: "transparent",
+          },
+          styleRest,
+        ]}
+      >
+        {children}
+      </View>
+    </View>
+  );
+};
+
+const sqrt2 = Math.sqrt(2);
+const centerBlockInsetGain = 1 - sqrt2 / 2;
+
+const NotchedRectangle: React.FC<{
+  color: string;
+  style?: StyleProp<ViewStyle>;
+  notchRadius: number;
+}> = ({ color, style, notchRadius }) => {
+  // mathed
+  const centerBlockSize = notchRadius * sqrt2;
+  const centerBlockInset = notchRadius * centerBlockInsetGain;
+
+  // this is black magic, should do the math to get proper formulas
+  const brokenRadius = notchRadius * 1.7;
+  const fillersHeight = brokenRadius - notchRadius;
+  const fillersWidth = notchRadius * 0.505;
+  return (
+    <View
+      style={[
+        {
+          borderTopLeftRadius: brokenRadius,
+          borderBottomRightRadius: brokenRadius,
+          backgroundColor: color,
+        },
+        style,
+      ]}
+    >
+      <View
+        style={{
+          height: fillersHeight,
+          width: fillersWidth,
+          backgroundColor: color,
+          position: "absolute",
+          top: notchRadius,
+          left: 0,
+        }}
+      />
+      <View
+        style={{
+          height: fillersWidth,
+          width: fillersHeight,
+          backgroundColor: color,
+          position: "absolute",
+          top: 0,
+          left: notchRadius,
+        }}
+      />
+      <View
+        style={{
+          height: centerBlockSize,
+          width: centerBlockSize,
+          backgroundColor: color,
+          position: "absolute",
+          transform: [
+            { translateX: centerBlockInset },
+            { translateY: centerBlockInset },
+            { rotate: "45deg" },
+          ],
+        }}
+      />
+      <View
+        style={{
+          height: fillersHeight,
+          width: fillersWidth,
+          backgroundColor: color,
+          position: "absolute",
+          bottom: notchRadius,
+          right: 0,
+        }}
+      />
+      <View
+        style={{
+          height: fillersWidth,
+          width: fillersHeight,
+          backgroundColor: color,
+          position: "absolute",
+          bottom: 0,
+          right: notchRadius,
+        }}
+      />
+      <View
+        style={{
+          height: centerBlockSize,
+          width: centerBlockSize,
+          backgroundColor: color,
+          position: "absolute",
+          transform: [
+            { translateX: -centerBlockInset },
+            { translateY: -centerBlockInset },
+            { rotate: "45deg" },
+          ],
+          bottom: 0,
+          right: 0,
+        }}
+      />
+    </View>
+  );
+};

--- a/packages/components/boxes/LegacyPrimaryBox.tsx
+++ b/packages/components/boxes/LegacyPrimaryBox.tsx
@@ -1,0 +1,196 @@
+import { LinearGradient } from "expo-linear-gradient";
+import React, { ReactNode } from "react";
+import { View, ViewStyle, StyleProp, StyleSheet } from "react-native";
+
+import { neutral11, neutral67 } from "../../utils/style/colors";
+
+/**
+ * @deprecated use PrimaryBox or Box instead
+ */
+export const LegacyPrimaryBox: React.FC<{
+  width?: number;
+  height?: number;
+  fullWidth?: boolean;
+  squaresBackgroundColor?: string;
+  disabled?: boolean;
+  style?: StyleProp<ViewStyle>;
+  mainContainerStyle?: StyleProp<ViewStyle>;
+  noBrokenCorners?: boolean;
+  colors?: string[];
+  noRightBrokenBorder?: boolean;
+  children: ReactNode;
+}> = ({
+  width,
+  height,
+  fullWidth = false,
+  squaresBackgroundColor = "#000000",
+  disabled = false,
+  style,
+  mainContainerStyle,
+  children,
+  colors,
+  noBrokenCorners,
+  noRightBrokenBorder,
+}) => {
+  const flatMainContainerStyle = mainContainerStyle
+    ? StyleSheet.flatten(mainContainerStyle)
+    : {};
+  const borderRadius = flatMainContainerStyle.borderRadius || 8;
+  const backgroundColor = disabled
+    ? neutral11
+    : flatMainContainerStyle.backgroundColor || "#000000";
+
+  return (
+    // ---- Main container, flex row to fit the horizontal content
+    <View
+      style={[{ flexDirection: "row" }, fullWidth && { width: "100%" }, style]}
+    >
+      {/* ---- Sub main container, flex column to fit the vertical content*/}
+      <View style={fullWidth && { width: "100%" }}>
+        {/*---- Content wrapper*/}
+        <View
+          style={[
+            height ? { height } : null,
+            width ? { width } : fullWidth ? { width: "100%" } : null,
+          ]}
+        >
+          {/*Main gradient*/}
+          <LinearGradient
+            // Be careful with these coordinates
+            // TODO: Find dynamic values depending on the ratio width/height to get a correct gradient angle everytime
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            locations={[0.7, 0.8]}
+            style={[
+              height ? { height } : null,
+              width ? { width } : fullWidth ? { width: "100%" } : null,
+              {
+                opacity: disabled ? 0.5 : 1,
+                borderRadius,
+                padding: 1,
+              },
+            ]}
+            colors={
+              disabled
+                ? [neutral67, "#B7B7B7"]
+                : colors
+                  ? colors
+                  : ["#01B7C5", "#782C96"]
+            }
+          >
+            {/* ---- Content container */}
+            <View
+              style={[
+                height ? { height: height - 2 } : null,
+                width
+                  ? { width: width - 2 }
+                  : fullWidth
+                    ? { width: "100%" }
+                    : null,
+                {
+                  backgroundColor,
+                  borderRadius,
+                  zIndex: 1,
+                  alignItems: "center",
+                  justifyContent: "center",
+                },
+                mainContainerStyle,
+              ]}
+            >
+              <>{children}</>
+            </View>
+
+            {!noBrokenCorners && (
+              <>
+                {/* Left top broken corner */}
+                <View
+                  style={{
+                    width: 8,
+                    height: 20,
+                    left: -1,
+                    top: -7,
+                    backgroundColor: squaresBackgroundColor,
+                    transform: [{ rotate: "45deg" }],
+                    position: "absolute",
+                    zIndex: 3,
+                  }}
+                />
+
+                {/* Left top gradient (Be careful with the coordinates and the colors)*/}
+                <LinearGradient
+                  start={{ x: -1, y: 0 }}
+                  end={{ x: 1, y: -1 }}
+                  style={{
+                    width: 8,
+                    height: 17,
+                    left: 0,
+                    top: -4.5,
+                    backgroundColor: squaresBackgroundColor,
+                    opacity: disabled ? 0.5 : 1,
+                    transform: [{ rotate: "45deg" }],
+                    position: "absolute",
+                    zIndex: 2,
+                  }}
+                  // Approximate colors for the corners border, no inconvenient visible to naked eyes.
+                  colors={
+                    disabled
+                      ? [neutral67, "#666666"]
+                      : colors
+                        ? [colors[0], colors[0]]
+                        : ["#04B4C4", "#04B3C3"]
+                  }
+                />
+
+                {/*Right bottom broken corner */}
+                {!noRightBrokenBorder && (
+                  <>
+                    <View
+                      style={{
+                        width: 8,
+                        height: 20,
+                        right: -1,
+                        bottom: -7,
+                        transform: [{ rotate: "225deg" }],
+                        backgroundColor: squaresBackgroundColor,
+                        position: "absolute",
+                        zIndex: 3,
+                      }}
+                    />
+
+                    {/* Right bottom gradient (Be careful with the coordinates and the colors)*/}
+                    <LinearGradient
+                      start={{ x: -1, y: 0 }}
+                      end={{ x: 1, y: -1 }}
+                      style={{
+                        width: 8,
+                        height: 17,
+                        right: 0,
+                        bottom: -4.5,
+                        backgroundColor: squaresBackgroundColor,
+                        opacity: disabled ? 0.5 : 1,
+                        transform: [{ rotate: "45deg" }],
+                        position: "absolute",
+                        zIndex: 2,
+                      }}
+                      // Approximate colors for the corners border, no inconvenient visible to naked eyes.
+                      colors={
+                        disabled
+                          ? ["#B7B7B7", "#bebbbb"]
+                          : colors
+                            ? [
+                                colors[colors.length - 1],
+                                colors[colors.length - 1],
+                              ]
+                            : ["#7c31a0", "#7c2fa2"]
+                      }
+                    />
+                  </>
+                )}
+              </>
+            )}
+          </LinearGradient>
+        </View>
+      </View>
+    </View>
+  );
+};

--- a/packages/components/boxes/LegacySecondaryBox.tsx
+++ b/packages/components/boxes/LegacySecondaryBox.tsx
@@ -1,0 +1,126 @@
+import React, { ReactNode } from "react";
+import { View, ViewStyle, StyleProp, StyleSheet } from "react-native";
+
+import { neutral11 } from "../../utils/style/colors";
+
+/**
+ * @deprecated use SecondaryBox or Box instead
+ */
+export const LegacySecondaryBox: React.FC<{
+  width?: number;
+  height?: number;
+  fullWidth?: boolean;
+  cornerWidth?: number;
+  squaresBackgroundColor?: string;
+  disabled?: boolean;
+  style?: StyleProp<ViewStyle>;
+  mainContainerStyle?: StyleProp<ViewStyle>;
+  noBrokenCorners?: boolean;
+  squaresBorderColor?: string;
+  children: ReactNode;
+}> = ({
+  width,
+  height,
+  fullWidth = false,
+  // Less or more big "broken" corner (Example on SocialButton)
+  cornerWidth = 8,
+  // We need that to correctly set the color under the card
+  squaresBackgroundColor = "#000000",
+  disabled = false,
+  style,
+  mainContainerStyle,
+  noBrokenCorners,
+  squaresBorderColor,
+  children,
+}) => {
+  const flatMainContainerStyle = mainContainerStyle
+    ? StyleSheet.flatten(mainContainerStyle)
+    : {};
+  const borderRadius = flatMainContainerStyle.borderRadius || 8;
+  const backgroundColor = disabled
+    ? neutral11
+    : flatMainContainerStyle.backgroundColor || "#000000";
+
+  return (
+    // ---- Main container, flex row to fit the horizontal content
+    <View
+      style={[{ flexDirection: "row" }, fullWidth && { width: "100%" }, style]}
+    >
+      {/* ---- Sub main container, flex column to fit the vertical content*/}
+      <View style={fullWidth && { width: "100%" }}>
+        {/*---- Content wrapper*/}
+        <View
+          style={[
+            height ? { height } : null,
+            width ? { width } : fullWidth ? { width: "100%" } : null,
+          ]}
+        >
+          {/* ---- Content container */}
+          <View
+            style={[
+              width ? { width } : fullWidth ? { width: "100%" } : null,
+              height ? { height } : null,
+              {
+                backgroundColor,
+                borderRadius,
+                alignItems: "center",
+                justifyContent: "center",
+              },
+              mainContainerStyle,
+            ]}
+          >
+            <>{children}</>
+          </View>
+
+          {!noBrokenCorners && (
+            <>
+              {/* Left top broken corner */}
+              <View
+                style={[
+                  {
+                    width: cornerWidth,
+                    height: 18,
+                    left: -0.5,
+                    top: -5.5,
+                    backgroundColor: squaresBackgroundColor,
+                    transform: [{ rotate: "45deg" }],
+                    position: "absolute",
+                    zIndex: 2,
+                  },
+                  squaresBorderColor
+                    ? {
+                        borderColor: squaresBorderColor,
+                        borderRightWidth: 1,
+                      }
+                    : {},
+                ]}
+              />
+
+              {/* Right bottom broken corner */}
+              <View
+                style={[
+                  {
+                    width: cornerWidth,
+                    height: 18,
+                    right: -0.5,
+                    bottom: -5.5,
+                    transform: [{ rotate: "225deg" }],
+                    backgroundColor: squaresBackgroundColor,
+                    position: "absolute",
+                    zIndex: 2,
+                  },
+                  squaresBorderColor
+                    ? {
+                        borderColor: squaresBorderColor,
+                        borderRightWidth: 1,
+                      }
+                    : {},
+                ]}
+              />
+            </>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+};

--- a/packages/components/boxes/LegacyTertiaryBox.tsx
+++ b/packages/components/boxes/LegacyTertiaryBox.tsx
@@ -1,0 +1,144 @@
+import { LinearGradient } from "expo-linear-gradient";
+import React, { ReactNode } from "react";
+import {
+  View,
+  ViewStyle,
+  StyleProp,
+  StyleSheet,
+  DimensionValue,
+} from "react-native";
+
+import { neutral11, neutral33, neutral44 } from "../../utils/style/colors";
+
+/**
+ * @deprecated use TertiaryBox or Box instead
+ */
+export const LegacyTertiaryBox: React.FC<{
+  width?: DimensionValue;
+  height?: DimensionValue;
+  fullWidth?: boolean;
+  squaresBackgroundColor?: string;
+  disabled?: boolean;
+  hasGradientBackground?: boolean;
+  style?: StyleProp<ViewStyle>;
+  mainContainerStyle?: StyleProp<ViewStyle>;
+  disabledBorderColor?: string;
+  noBrokenCorners?: boolean;
+  noRightBrokenBorder?: boolean;
+  children: ReactNode;
+}> = ({
+  width,
+  height,
+  fullWidth = false,
+  squaresBackgroundColor = "#000000",
+  children,
+  disabled = false,
+  hasGradientBackground = false,
+  style,
+  mainContainerStyle,
+  noBrokenCorners,
+  disabledBorderColor,
+  noRightBrokenBorder,
+}) => {
+  const brokenCornerWidth = 1;
+  const flatMainContainerStyle = mainContainerStyle
+    ? StyleSheet.flatten(mainContainerStyle)
+    : {};
+  const borderRadius = flatMainContainerStyle.borderRadius || 8;
+  const borderColor = disabled
+    ? disabledBorderColor || neutral44
+    : flatMainContainerStyle.borderColor || neutral33;
+  const backgroundColor = disabled
+    ? neutral11
+    : flatMainContainerStyle.backgroundColor || "#000000";
+
+  return (
+    // ---- Main container, flex row to fit the horizontal content
+    <View
+      style={[{ flexDirection: "row" }, fullWidth && { width: "100%" }, style]}
+    >
+      {/* ---- Sub main container, flex column to fit the vertical content*/}
+      <View style={fullWidth && { width: "100%" }}>
+        {/*---- Content wrapper*/}
+        <View
+          style={[
+            height ? { height } : null,
+            width ? { width } : fullWidth ? { width: "100%" } : null,
+          ]}
+        >
+          {/* ---- Content container */}
+          <View
+            style={[
+              width ? { width } : fullWidth ? { width: "100%" } : null,
+              height ? { height } : null,
+              {
+                backgroundColor,
+                borderColor,
+                borderWidth: 1,
+                borderRadius,
+                alignItems: "center",
+                justifyContent: "center",
+              },
+              mainContainerStyle,
+            ]}
+          >
+            {hasGradientBackground ? (
+              <LinearGradient
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  height: "100%",
+                  borderRadius:
+                    (typeof borderRadius === "number" ? borderRadius : 8) - 1,
+                  zIndex: -1,
+                }}
+                colors={["#9C4CEA", "#336AFF", "#26C5FB"]}
+              />
+            ) : null}
+            <>{children}</>
+          </View>
+
+          {!noBrokenCorners && (
+            <>
+              {/* Left top broken corner */}
+              <View
+                style={{
+                  width: 8,
+                  height: 18,
+                  left: 0,
+                  top: -5,
+                  backgroundColor: squaresBackgroundColor,
+                  borderRightColor: borderColor,
+                  borderRightWidth: brokenCornerWidth,
+                  transform: [{ rotate: "45deg" }],
+                  position: "absolute",
+                  zIndex: 2,
+                }}
+              />
+
+              {/* Right bottom broken corner */}
+              {!noRightBrokenBorder && (
+                <View
+                  style={{
+                    width: 8,
+                    height: 18,
+                    right: 0,
+                    bottom: -5,
+                    transform: [{ rotate: "225deg" }],
+                    backgroundColor: squaresBackgroundColor,
+                    borderRightColor: borderColor,
+                    borderRightWidth: brokenCornerWidth,
+                    position: "absolute",
+                    zIndex: 2,
+                  }}
+                />
+              )}
+            </>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+};

--- a/packages/components/boxes/PrimaryBox.tsx
+++ b/packages/components/boxes/PrimaryBox.tsx
@@ -1,193 +1,24 @@
-import { LinearGradient } from "expo-linear-gradient";
-import React, { ReactNode } from "react";
-import { View, ViewStyle, StyleProp, StyleSheet } from "react-native";
+import { ReactNode } from "react";
+import { StyleProp } from "react-native";
 
-import { neutral11, neutral67 } from "../../utils/style/colors";
+import { BoxStyle, Box, GradientParams } from "./Box";
+
+// Default gradient borders box
 
 export const PrimaryBox: React.FC<{
-  width?: number;
-  height?: number;
-  fullWidth?: boolean;
-  squaresBackgroundColor?: string;
-  disabled?: boolean;
-  style?: StyleProp<ViewStyle>;
-  mainContainerStyle?: StyleProp<ViewStyle>;
-  noBrokenCorners?: boolean;
-  colors?: string[];
-  noRightBrokenBorder?: boolean;
   children: ReactNode;
-}> = ({
-  width,
-  height,
-  fullWidth = false,
-  squaresBackgroundColor = "#000000",
-  disabled = false,
-  style,
-  mainContainerStyle,
-  children,
-  colors,
-  noBrokenCorners,
-  noRightBrokenBorder,
-}) => {
-  const flatMainContainerStyle = mainContainerStyle
-    ? StyleSheet.flatten(mainContainerStyle)
-    : {};
-  const borderRadius = flatMainContainerStyle.borderRadius || 8;
-  const backgroundColor = disabled
-    ? neutral11
-    : flatMainContainerStyle.backgroundColor || "#000000";
-
+  style?: StyleProp<BoxStyle>;
+}> = ({ children, style }) => {
   return (
-    // ---- Main container, flex row to fit the horizontal content
-    <View
-      style={[{ flexDirection: "row" }, fullWidth && { width: "100%" }, style]}
-    >
-      {/* ---- Sub main container, flex column to fit the vertical content*/}
-      <View style={fullWidth && { width: "100%" }}>
-        {/*---- Content wrapper*/}
-        <View
-          style={[
-            height ? { height } : null,
-            width ? { width } : fullWidth ? { width: "100%" } : null,
-          ]}
-        >
-          {/*Main gradient*/}
-          <LinearGradient
-            // Be careful with these coordinates
-            // TODO: Find dynamic values depending on the ratio width/height to get a correct gradient angle everytime
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 1 }}
-            locations={[0.7, 0.8]}
-            style={[
-              height ? { height } : null,
-              width ? { width } : fullWidth ? { width: "100%" } : null,
-              {
-                opacity: disabled ? 0.5 : 1,
-                borderRadius,
-                padding: 1,
-              },
-            ]}
-            colors={
-              disabled
-                ? [neutral67, "#B7B7B7"]
-                : colors
-                  ? colors
-                  : ["#01B7C5", "#782C96"]
-            }
-          >
-            {/* ---- Content container */}
-            <View
-              style={[
-                height ? { height: height - 2 } : null,
-                width
-                  ? { width: width - 2 }
-                  : fullWidth
-                    ? { width: "100%" }
-                    : null,
-                {
-                  backgroundColor,
-                  borderRadius,
-                  zIndex: 1,
-                  alignItems: "center",
-                  justifyContent: "center",
-                },
-                mainContainerStyle,
-              ]}
-            >
-              <>{children}</>
-            </View>
-
-            {!noBrokenCorners && (
-              <>
-                {/* Left top broken corner */}
-                <View
-                  style={{
-                    width: 8,
-                    height: 20,
-                    left: -1,
-                    top: -7,
-                    backgroundColor: squaresBackgroundColor,
-                    transform: [{ rotate: "45deg" }],
-                    position: "absolute",
-                    zIndex: 3,
-                  }}
-                />
-
-                {/* Left top gradient (Be careful with the coordinates and the colors)*/}
-                <LinearGradient
-                  start={{ x: -1, y: 0 }}
-                  end={{ x: 1, y: -1 }}
-                  style={{
-                    width: 8,
-                    height: 17,
-                    left: 0,
-                    top: -4.5,
-                    backgroundColor: squaresBackgroundColor,
-                    opacity: disabled ? 0.5 : 1,
-                    transform: [{ rotate: "45deg" }],
-                    position: "absolute",
-                    zIndex: 2,
-                  }}
-                  // Approximate colors for the corners border, no inconvenient visible to naked eyes.
-                  colors={
-                    disabled
-                      ? [neutral67, "#666666"]
-                      : colors
-                        ? [colors[0], colors[0]]
-                        : ["#04B4C4", "#04B3C3"]
-                  }
-                />
-
-                {/*Right bottom broken corner */}
-                {!noRightBrokenBorder && (
-                  <>
-                    <View
-                      style={{
-                        width: 8,
-                        height: 20,
-                        right: -1,
-                        bottom: -7,
-                        transform: [{ rotate: "225deg" }],
-                        backgroundColor: squaresBackgroundColor,
-                        position: "absolute",
-                        zIndex: 3,
-                      }}
-                    />
-
-                    {/* Right bottom gradient (Be careful with the coordinates and the colors)*/}
-                    <LinearGradient
-                      start={{ x: -1, y: 0 }}
-                      end={{ x: 1, y: -1 }}
-                      style={{
-                        width: 8,
-                        height: 17,
-                        right: 0,
-                        bottom: -4.5,
-                        backgroundColor: squaresBackgroundColor,
-                        opacity: disabled ? 0.5 : 1,
-                        transform: [{ rotate: "45deg" }],
-                        position: "absolute",
-                        zIndex: 2,
-                      }}
-                      // Approximate colors for the corners border, no inconvenient visible to naked eyes.
-                      colors={
-                        disabled
-                          ? ["#B7B7B7", "#bebbbb"]
-                          : colors
-                            ? [
-                                colors[colors.length - 1],
-                                colors[colors.length - 1],
-                              ]
-                            : ["#7c31a0", "#7c2fa2"]
-                      }
-                    />
-                  </>
-                )}
-              </>
-            )}
-          </LinearGradient>
-        </View>
-      </View>
-    </View>
+    <Box borderGradient={borderGradient} style={[{ borderWidth: 1 }, style]}>
+      {children}
+    </Box>
   );
+};
+
+const borderGradient: GradientParams = {
+  start: { x: 0, y: 0 },
+  end: { x: 1, y: 0.3 },
+  locations: [-0.008, 1.0484],
+  colors: ["#01B7C5", "#782C96"],
 };

--- a/packages/components/boxes/SecondaryBox.tsx
+++ b/packages/components/boxes/SecondaryBox.tsx
@@ -1,123 +1,17 @@
 import React, { ReactNode } from "react";
-import { View, ViewStyle, StyleProp, StyleSheet } from "react-native";
+import { StyleProp } from "react-native";
 
-import { neutral11 } from "../../utils/style/colors";
+import { BoxStyle, Box } from "./Box";
+
+// Simple box with no borders and notched corners
 
 export const SecondaryBox: React.FC<{
-  width?: number;
-  height?: number;
-  fullWidth?: boolean;
-  cornerWidth?: number;
-  squaresBackgroundColor?: string;
-  disabled?: boolean;
-  style?: StyleProp<ViewStyle>;
-  mainContainerStyle?: StyleProp<ViewStyle>;
-  noBrokenCorners?: boolean;
-  squaresBorderColor?: string;
-  children: ReactNode;
-}> = ({
-  width,
-  height,
-  fullWidth = false,
-  // Less or more big "broken" corner (Example on SocialButton)
-  cornerWidth = 8,
-  // We need that to correctly set the color under the card
-  squaresBackgroundColor = "#000000",
-  disabled = false,
-  style,
-  mainContainerStyle,
-  noBrokenCorners,
-  squaresBorderColor,
-  children,
-}) => {
-  const flatMainContainerStyle = mainContainerStyle
-    ? StyleSheet.flatten(mainContainerStyle)
-    : {};
-  const borderRadius = flatMainContainerStyle.borderRadius || 8;
-  const backgroundColor = disabled
-    ? neutral11
-    : flatMainContainerStyle.backgroundColor || "#000000";
-
+  children?: ReactNode;
+  style?: StyleProp<BoxStyle>;
+}> = ({ style, children }) => {
   return (
-    // ---- Main container, flex row to fit the horizontal content
-    <View
-      style={[{ flexDirection: "row" }, fullWidth && { width: "100%" }, style]}
-    >
-      {/* ---- Sub main container, flex column to fit the vertical content*/}
-      <View style={fullWidth && { width: "100%" }}>
-        {/*---- Content wrapper*/}
-        <View
-          style={[
-            height ? { height } : null,
-            width ? { width } : fullWidth ? { width: "100%" } : null,
-          ]}
-        >
-          {/* ---- Content container */}
-          <View
-            style={[
-              width ? { width } : fullWidth ? { width: "100%" } : null,
-              height ? { height } : null,
-              {
-                backgroundColor,
-                borderRadius,
-                alignItems: "center",
-                justifyContent: "center",
-              },
-              mainContainerStyle,
-            ]}
-          >
-            <>{children}</>
-          </View>
-
-          {!noBrokenCorners && (
-            <>
-              {/* Left top broken corner */}
-              <View
-                style={[
-                  {
-                    width: cornerWidth,
-                    height: 18,
-                    left: -0.5,
-                    top: -5.5,
-                    backgroundColor: squaresBackgroundColor,
-                    transform: [{ rotate: "45deg" }],
-                    position: "absolute",
-                    zIndex: 2,
-                  },
-                  squaresBorderColor
-                    ? {
-                        borderColor: squaresBorderColor,
-                        borderRightWidth: 1,
-                      }
-                    : {},
-                ]}
-              />
-
-              {/* Right bottom broken corner */}
-              <View
-                style={[
-                  {
-                    width: cornerWidth,
-                    height: 18,
-                    right: -0.5,
-                    bottom: -5.5,
-                    transform: [{ rotate: "225deg" }],
-                    backgroundColor: squaresBackgroundColor,
-                    position: "absolute",
-                    zIndex: 2,
-                  },
-                  squaresBorderColor
-                    ? {
-                        borderColor: squaresBorderColor,
-                        borderRightWidth: 1,
-                      }
-                    : {},
-                ]}
-              />
-            </>
-          )}
-        </View>
-      </View>
-    </View>
+    <Box notched style={style}>
+      {children}
+    </Box>
   );
 };

--- a/packages/components/boxes/TertiaryBox.tsx
+++ b/packages/components/boxes/TertiaryBox.tsx
@@ -1,141 +1,27 @@
-import { LinearGradient } from "expo-linear-gradient";
 import React, { ReactNode } from "react";
-import {
-  View,
-  ViewStyle,
-  StyleProp,
-  StyleSheet,
-  DimensionValue,
-} from "react-native";
+import { StyleProp } from "react-native";
 
-import { neutral11, neutral33, neutral44 } from "../../utils/style/colors";
+import { BoxStyle, Box } from "./Box";
+import { neutral33 } from "../../utils/style/colors";
+
+// Box with notched corners and a border
 
 export const TertiaryBox: React.FC<{
-  width?: DimensionValue;
-  height?: DimensionValue;
-  fullWidth?: boolean;
-  squaresBackgroundColor?: string;
-  disabled?: boolean;
-  hasGradientBackground?: boolean;
-  style?: StyleProp<ViewStyle>;
-  mainContainerStyle?: StyleProp<ViewStyle>;
-  disabledBorderColor?: string;
-  noBrokenCorners?: boolean;
-  noRightBrokenBorder?: boolean;
-  children: ReactNode;
-}> = ({
-  width,
-  height,
-  fullWidth = false,
-  squaresBackgroundColor = "#000000",
-  children,
-  disabled = false,
-  hasGradientBackground = false,
-  style,
-  mainContainerStyle,
-  noBrokenCorners,
-  disabledBorderColor,
-  noRightBrokenBorder,
-}) => {
-  const brokenCornerWidth = 1;
-  const flatMainContainerStyle = mainContainerStyle
-    ? StyleSheet.flatten(mainContainerStyle)
-    : {};
-  const borderRadius = flatMainContainerStyle.borderRadius || 8;
-  const borderColor = disabled
-    ? disabledBorderColor || neutral44
-    : flatMainContainerStyle.borderColor || neutral33;
-  const backgroundColor = disabled
-    ? neutral11
-    : flatMainContainerStyle.backgroundColor || "#000000";
-
+  children?: ReactNode;
+  style?: StyleProp<BoxStyle>;
+}> = ({ style, children }) => {
   return (
-    // ---- Main container, flex row to fit the horizontal content
-    <View
-      style={[{ flexDirection: "row" }, fullWidth && { width: "100%" }, style]}
+    <Box
+      notched
+      style={[
+        {
+          borderWidth: 1,
+          borderColor: neutral33,
+        },
+        style,
+      ]}
     >
-      {/* ---- Sub main container, flex column to fit the vertical content*/}
-      <View style={fullWidth && { width: "100%" }}>
-        {/*---- Content wrapper*/}
-        <View
-          style={[
-            height ? { height } : null,
-            width ? { width } : fullWidth ? { width: "100%" } : null,
-          ]}
-        >
-          {/* ---- Content container */}
-          <View
-            style={[
-              width ? { width } : fullWidth ? { width: "100%" } : null,
-              height ? { height } : null,
-              {
-                backgroundColor,
-                borderColor,
-                borderWidth: 1,
-                borderRadius,
-                alignItems: "center",
-                justifyContent: "center",
-              },
-              mainContainerStyle,
-            ]}
-          >
-            {hasGradientBackground ? (
-              <LinearGradient
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  width: "100%",
-                  height: "100%",
-                  borderRadius:
-                    (typeof borderRadius === "number" ? borderRadius : 8) - 1,
-                  zIndex: -1,
-                }}
-                colors={["#9C4CEA", "#336AFF", "#26C5FB"]}
-              />
-            ) : null}
-            <>{children}</>
-          </View>
-
-          {!noBrokenCorners && (
-            <>
-              {/* Left top broken corner */}
-              <View
-                style={{
-                  width: 8,
-                  height: 18,
-                  left: 0,
-                  top: -5,
-                  backgroundColor: squaresBackgroundColor,
-                  borderRightColor: borderColor,
-                  borderRightWidth: brokenCornerWidth,
-                  transform: [{ rotate: "45deg" }],
-                  position: "absolute",
-                  zIndex: 2,
-                }}
-              />
-
-              {/* Right bottom broken corner */}
-              {!noRightBrokenBorder && (
-                <View
-                  style={{
-                    width: 8,
-                    height: 18,
-                    right: 0,
-                    bottom: -5,
-                    transform: [{ rotate: "225deg" }],
-                    backgroundColor: squaresBackgroundColor,
-                    borderRightColor: borderColor,
-                    borderRightWidth: brokenCornerWidth,
-                    position: "absolute",
-                    zIndex: 2,
-                  }}
-                />
-              )}
-            </>
-          )}
-        </View>
-      </View>
-    </View>
+      {children}
+    </Box>
   );
 };

--- a/packages/components/buttons/IconButton.tsx
+++ b/packages/components/buttons/IconButton.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../utils/style/buttons";
 import { primaryColor } from "../../utils/style/colors";
 import { SVG } from "../SVG";
-import { SecondaryBox } from "../boxes/SecondaryBox";
+import { LegacySecondaryBox } from "../boxes/LegacySecondaryBox";
 
 export const IconButton: React.FC<{
   width?: number;
@@ -55,7 +55,7 @@ export const IconButton: React.FC<{
       onPress={onPress}
       style={{ width: fullWidth ? "100%" : width }}
     >
-      <SecondaryBox
+      <LegacySecondaryBox
         height={heightButton(size)}
         mainContainerStyle={[
           {
@@ -75,7 +75,7 @@ export const IconButton: React.FC<{
           height={iconSize}
           color={iconColor}
         />
-      </SecondaryBox>
+      </LegacySecondaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/buttons/PrimaryButton.tsx
+++ b/packages/components/buttons/PrimaryButton.tsx
@@ -12,10 +12,15 @@ import {
   ButtonsSize,
   heightButton,
 } from "../../utils/style/buttons";
-import { primaryColor, primaryTextColor } from "../../utils/style/colors";
+import {
+  neutral11,
+  primaryColor,
+  primaryTextColor,
+} from "../../utils/style/colors";
 import { fontSemibold14 } from "../../utils/style/fonts";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
+import { BoxStyle } from "../boxes/Box";
 import { SecondaryBox } from "../boxes/SecondaryBox";
 
 export const PrimaryButton: React.FC<{
@@ -23,8 +28,7 @@ export const PrimaryButton: React.FC<{
   text: string;
   width?: number;
   onPress?: (() => Promise<void>) | (() => void);
-  squaresBackgroundColor?: string;
-  style?: StyleProp<ViewStyle>;
+  style?: StyleProp<BoxStyle>;
   iconSVG?: React.FC<SvgProps>;
   iconColor?: string;
   disabled?: boolean;
@@ -33,7 +37,6 @@ export const PrimaryButton: React.FC<{
   touchableStyle?: StyleProp<ViewStyle>;
   RightComponent?: React.FC;
   color?: string;
-  noBrokenCorners?: boolean;
   isLoading?: boolean;
 }> = ({
   // If no width, the buttons will fit the content including paddingHorizontal 20
@@ -41,7 +44,6 @@ export const PrimaryButton: React.FC<{
   size = "M",
   text,
   onPress,
-  squaresBackgroundColor,
   style,
   iconSVG,
   disabled = false,
@@ -51,7 +53,6 @@ export const PrimaryButton: React.FC<{
   RightComponent,
   iconColor,
   color = primaryColor,
-  noBrokenCorners = false,
   isLoading,
 }) => {
   const [isLocalLoading, setIsLocalLoading] = useState(false);
@@ -71,31 +72,34 @@ export const PrimaryButton: React.FC<{
 
   const isDisabled = !!(disabled || (loader && (isLocalLoading || isLoading)));
 
-  const boxProps = {
-    style,
-    disabled,
-    squaresBackgroundColor,
-    width,
-    fullWidth,
-    noBrokenCorners,
-  };
-
   return (
     <TouchableOpacity
       onPress={onPress ? handlePress : undefined}
       disabled={isDisabled}
-      style={[{ width: fullWidth ? "100%" : width }, touchableStyle]}
+      style={[
+        {
+          width: fullWidth ? "100%" : width,
+          flexDirection: "row",
+        },
+        touchableStyle,
+      ]}
     >
       <SecondaryBox
-        height={heightButton(size)}
-        mainContainerStyle={{
-          flexDirection: "row",
-          borderRadius: borderRadiusButton(size),
-          backgroundColor: color,
-          paddingHorizontal: 20,
-          opacity: isDisabled ? 0.5 : 1,
-        }}
-        {...boxProps}
+        style={[
+          {
+            flexDirection: "row",
+            borderRadius: borderRadiusButton(size),
+            backgroundColor: disabled ? neutral11 : color,
+            padding: 0,
+            paddingHorizontal: 20,
+            opacity: isDisabled ? 0.5 : 1,
+            height: heightButton(size),
+            alignItems: "center",
+            justifyContent: "center",
+            width: fullWidth ? "100%" : width,
+          },
+          style,
+        ]}
       >
         {iconSVG ? (
           <SVG

--- a/packages/components/buttons/PrimaryButtonOutline.tsx
+++ b/packages/components/buttons/PrimaryButtonOutline.tsx
@@ -17,7 +17,7 @@ import { primaryColor } from "../../utils/style/colors";
 import { fontSemibold14 } from "../../utils/style/fonts";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 export const PrimaryButtonOutline: React.FC<{
   size: ButtonsSize;
@@ -68,7 +68,7 @@ export const PrimaryButtonOutline: React.FC<{
         touchableStyle,
       ]}
     >
-      <TertiaryBox
+      <LegacyTertiaryBox
         height={heightButton(size)}
         mainContainerStyle={{
           flexDirection: "row",
@@ -98,7 +98,7 @@ export const PrimaryButtonOutline: React.FC<{
             </BrandText>
           </>
         )}
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/buttons/SecondaryButton.tsx
+++ b/packages/components/buttons/SecondaryButton.tsx
@@ -17,7 +17,7 @@ import { neutral30, primaryColor } from "../../utils/style/colors";
 import { fontSemibold14 } from "../../utils/style/fonts";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
-import { SecondaryBox } from "../boxes/SecondaryBox";
+import { LegacySecondaryBox } from "../boxes/LegacySecondaryBox";
 
 // TODO: fix size changing on loading, like in SecondaryButtonOutline
 
@@ -90,7 +90,7 @@ export const SecondaryButton: React.FC<{
       style={[{ width: fullWidth ? "100%" : width }, touchableStyle]}
       activeOpacity={activeOpacity}
     >
-      <SecondaryBox
+      <LegacySecondaryBox
         height={heightButton(size)}
         mainContainerStyle={{
           flexDirection: "row",
@@ -127,7 +127,7 @@ export const SecondaryButton: React.FC<{
             </BrandText>
           </>
         )}
-      </SecondaryBox>
+      </LegacySecondaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/buttons/SecondaryButtonOutline.tsx
+++ b/packages/components/buttons/SecondaryButtonOutline.tsx
@@ -12,7 +12,7 @@ import { neutral33, secondaryColor } from "../../utils/style/colors";
 import { fontSemibold14 } from "../../utils/style/fonts";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 // FIXME: make a BaseButton and only pass backgroun/border and text colors in this kind of components
 
@@ -81,7 +81,7 @@ export const SecondaryButtonOutline: React.FC<{
       disabled={disabled}
       style={[{ width: fullWidth ? "100%" : width }, touchableStyle]}
     >
-      <TertiaryBox
+      <LegacyTertiaryBox
         height={heightButton(size)}
         mainContainerStyle={{
           flexDirection: "row",
@@ -125,7 +125,7 @@ export const SecondaryButtonOutline: React.FC<{
               <ActivityIndicator color={color} size="small" />
             </View>
           ))}
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/buttons/SocialButton.tsx
+++ b/packages/components/buttons/SocialButton.tsx
@@ -6,7 +6,7 @@ import { neutral22, neutral33, withAlpha } from "../../utils/style/colors";
 import { fontMedium14 } from "../../utils/style/fonts";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
-import { SecondaryBox } from "../boxes/SecondaryBox";
+import { LegacySecondaryBox } from "../boxes/LegacySecondaryBox";
 
 export const SocialButton: React.FC<{
   text: string;
@@ -17,14 +17,14 @@ export const SocialButton: React.FC<{
 }> = ({ text, onPress, iconSvg, style, noBrokenCorners = true }) => {
   return (
     <TouchableOpacity onPress={onPress} style={style}>
-      <SecondaryBox
+      <LegacySecondaryBox
         // We don't handle broken corners for now, because this button can be used on an image
         noBrokenCorners={noBrokenCorners}
         mainContainerStyle={{ backgroundColor: withAlpha(neutral22, 0.64) }}
         height={44}
       >
         <View style={{ flexDirection: "row", alignItems: "center" }}>
-          <SecondaryBox
+          <LegacySecondaryBox
             noBrokenCorners={noBrokenCorners}
             style={{ marginLeft: 6 }}
             mainContainerStyle={{ backgroundColor: neutral33, borderRadius: 6 }}
@@ -34,12 +34,12 @@ export const SocialButton: React.FC<{
             cornerWidth={5.5}
           >
             <SVG source={iconSvg} height={20} width={20} />
-          </SecondaryBox>
+          </LegacySecondaryBox>
           <BrandText style={[fontMedium14, { marginLeft: 8, marginRight: 16 }]}>
             {text}
           </BrandText>
         </View>
-      </SecondaryBox>
+      </LegacySecondaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/buttons/SocialButtonSecondary.tsx
+++ b/packages/components/buttons/SocialButtonSecondary.tsx
@@ -11,7 +11,7 @@ import {
 import { fontMedium14 } from "../../utils/style/fonts";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
-import { SecondaryBox } from "../boxes/SecondaryBox";
+import { LegacySecondaryBox } from "../boxes/LegacySecondaryBox";
 
 export const SocialButtonSecondary: React.FC<{
   text: string;
@@ -21,13 +21,13 @@ export const SocialButtonSecondary: React.FC<{
 }> = ({ text, onPress, iconSvg, style }) => {
   return (
     <TouchableOpacity onPress={onPress} style={style}>
-      <SecondaryBox
+      <LegacySecondaryBox
         noBrokenCorners
         mainContainerStyle={{ backgroundColor: withAlpha(neutral1A, 0.64) }}
         height={44}
       >
         <View style={{ flexDirection: "row", alignItems: "center" }}>
-          <SecondaryBox
+          <LegacySecondaryBox
             noBrokenCorners
             style={{ marginLeft: 6 }}
             mainContainerStyle={{
@@ -45,7 +45,7 @@ export const SocialButtonSecondary: React.FC<{
               height={20}
               color={primaryTextColor}
             />
-          </SecondaryBox>
+          </LegacySecondaryBox>
           <BrandText
             style={[
               fontMedium14,
@@ -55,7 +55,7 @@ export const SocialButtonSecondary: React.FC<{
             {text}
           </BrandText>
         </View>
-      </SecondaryBox>
+      </LegacySecondaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/buttons/TertiaryButton.tsx
+++ b/packages/components/buttons/TertiaryButton.tsx
@@ -11,7 +11,7 @@ import { neutral33, neutral44 } from "../../utils/style/colors";
 import { fontSemibold14 } from "../../utils/style/fonts";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 export const TertiaryButton: React.FC<{
   size: ButtonsSize;
@@ -49,7 +49,7 @@ export const TertiaryButton: React.FC<{
       disabled={disabled}
       style={{ width: fullWidth ? "100%" : width }}
     >
-      <TertiaryBox
+      <LegacyTertiaryBox
         height={heightButton(size)}
         mainContainerStyle={{
           flexDirection: "row",
@@ -75,7 +75,7 @@ export const TertiaryButton: React.FC<{
         >
           {text}
         </BrandText>
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/buttons/ToggleableButton.tsx
+++ b/packages/components/buttons/ToggleableButton.tsx
@@ -12,7 +12,7 @@ import { neutral33, secondaryColor } from "../../utils/style/colors";
 import { fontSemibold12 } from "../../utils/style/fonts";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
-import { SecondaryBox } from "../boxes/SecondaryBox";
+import { LegacySecondaryBox } from "../boxes/LegacySecondaryBox";
 
 // Same as _PrimaryButtonTest but with customizable color and backgroundColor
 export const ToggleableButton: React.FC<{
@@ -44,7 +44,7 @@ export const ToggleableButton: React.FC<{
 
   return (
     <TouchableOpacity onPress={onPress}>
-      <SecondaryBox
+      <LegacySecondaryBox
         cornerWidth={cornerWidthDropdownButton(size)}
         height={heightDropdownButton(size)}
         mainContainerStyle={{
@@ -71,7 +71,7 @@ export const ToggleableButton: React.FC<{
           height={16}
           color={secondaryColor}
         />
-      </SecondaryBox>
+      </LegacySecondaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/buttons/TransparentButtonOutline.tsx
+++ b/packages/components/buttons/TransparentButtonOutline.tsx
@@ -22,7 +22,7 @@ import {
 import { fontSemibold14 } from "../../utils/style/fonts";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 export const TransparentButtonOutline: React.FC<{
   size: ButtonsSize;
@@ -70,7 +70,7 @@ export const TransparentButtonOutline: React.FC<{
       disabled={disabled}
       style={{ width: fullWidth ? "100%" : width }}
     >
-      <TertiaryBox
+      <LegacyTertiaryBox
         disabledBorderColor={neutral22}
         height={heightButton(size)}
         mainContainerStyle={{
@@ -101,7 +101,7 @@ export const TransparentButtonOutline: React.FC<{
             <RightComponent />
           </View>
         )}
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/cards/NFTAttributeCard.tsx
+++ b/packages/components/cards/NFTAttributeCard.tsx
@@ -14,7 +14,7 @@ import {
 import { layout } from "../../utils/style/layout";
 import { NFTInfo } from "../../utils/types/nft";
 import { BrandText } from "../BrandText";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 // TODO: Dynamic data + props
 
@@ -29,7 +29,7 @@ export const NFTAttributeCard: React.FC<{
   return (
     nftAttribute &&
     nftInfo && (
-      <TertiaryBox
+      <LegacyTertiaryBox
         height={92}
         width={isMobile && width < 380 ? 158 : 192}
         style={style}
@@ -103,7 +103,7 @@ export const NFTAttributeCard: React.FC<{
         >
           {nftAttribute.rareRatio.toFixed(2)}%
         </BrandText>
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     )
   );
 };

--- a/packages/components/cards/NFTCancelListingCard.tsx
+++ b/packages/components/cards/NFTCancelListingCard.tsx
@@ -6,7 +6,7 @@ import { fontSemibold12, fontSemibold28 } from "../../utils/style/fonts";
 import { NFTInfo } from "../../utils/types/nft";
 import { BrandText } from "../BrandText";
 import { CurrencyIcon } from "../CurrencyIcon";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { PrimaryButton } from "../buttons/PrimaryButton";
 import { GradientText } from "../gradientText";
 
@@ -16,7 +16,7 @@ export const NFTCancelListingCard: React.FC<{
   style?: StyleProp<ViewStyle>;
 }> = ({ nftInfo, onPressCancel, style }) => {
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       fullWidth
       height={88}
       style={style}
@@ -50,6 +50,6 @@ export const NFTCancelListingCard: React.FC<{
         loader
         onPress={onPressCancel}
       />
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };

--- a/packages/components/cards/NFTPriceBuyCard.tsx
+++ b/packages/components/cards/NFTPriceBuyCard.tsx
@@ -7,7 +7,7 @@ import { fontSemibold12, fontSemibold28 } from "../../utils/style/fonts";
 import { NFTInfo } from "../../utils/types/nft";
 import { BrandText } from "../BrandText";
 import { CurrencyIcon } from "../CurrencyIcon";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { PrimaryButton } from "../buttons/PrimaryButton";
 import { GradientText } from "../gradientText";
 
@@ -21,7 +21,7 @@ export const NFTPriceBuyCard: React.FC<{
   const isMobile = useIsMobile();
 
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       fullWidth
       height={88}
       style={style}
@@ -54,6 +54,6 @@ export const NFTPriceBuyCard: React.FC<{
         text="Buy this NFT"
         onPress={onPressBuy}
       />
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };

--- a/packages/components/cards/NFTSellCard.tsx
+++ b/packages/components/cards/NFTSellCard.tsx
@@ -7,7 +7,7 @@ import {
   keplrCurrencyFromNativeCurrencyInfo,
 } from "../../networks";
 import { NFTInfo } from "../../utils/types/nft";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { PrimaryButton } from "../buttons/PrimaryButton";
 import { TextInputCustom } from "../inputs/TextInputCustom";
 import { NFTSellInfo } from "../nftDetails/components/NFTSellInfo";
@@ -33,7 +33,7 @@ export const NFTSellCard: React.FC<{
   }
   return (
     <View style={style}>
-      <TertiaryBox
+      <LegacyTertiaryBox
         fullWidth
         height={88}
         style={{ marginBottom: 16 }}
@@ -58,7 +58,7 @@ export const NFTSellCard: React.FC<{
           text="List this NFT"
           onPress={handleSubmit(handleSell)}
         />
-      </TertiaryBox>
+      </LegacyTertiaryBox>
       <NFTSellInfo nftInfo={nftInfo} price={values.price} />
     </View>
   );

--- a/packages/components/cards/ProgressionCard.tsx
+++ b/packages/components/cards/ProgressionCard.tsx
@@ -4,7 +4,7 @@ import { ViewStyle, View, StyleProp } from "react-native";
 import { neutral44, neutral77, primaryColor } from "../../utils/style/colors";
 import { fontSemibold12, fontSemibold28 } from "../../utils/style/fonts";
 import { BrandText } from "../BrandText";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { GradientText } from "../gradientText";
 
 export const ProgressionCard: React.FC<{
@@ -16,7 +16,7 @@ export const ProgressionCard: React.FC<{
   const percent = Math.round((valueCurrent * 100) / valueMax);
 
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       style={style}
       height={100}
       fullWidth
@@ -71,6 +71,6 @@ export const ProgressionCard: React.FC<{
           />
         </View>
       </View>
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };

--- a/packages/components/cards/QuestCard.tsx
+++ b/packages/components/cards/QuestCard.tsx
@@ -1,32 +1,38 @@
 import { isEqual } from "lodash";
 import React, { memo } from "react";
-import { StyleProp, ViewStyle } from "react-native";
+import { StyleProp } from "react-native";
 
 import burnSVG from "../../../assets/icons/burn.svg";
-import { neutral17 } from "../../utils/style/colors";
+import { neutral17, neutral33 } from "../../utils/style/colors";
 import { fontSemibold12 } from "../../utils/style/fonts";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { Box, BoxStyle } from "../boxes/Box";
 import { SpacerColumn } from "../spacer";
 
 export const QuestCard: React.FC<{
   label: string;
   completed?: boolean;
-  style?: StyleProp<ViewStyle>;
+  style?: StyleProp<BoxStyle>;
   width?: number;
 }> = memo(({ label, completed = false, style, width = 140 }) => {
   return (
-    <TertiaryBox
-      width={width}
-      style={style}
-      hasGradientBackground={completed}
-      mainContainerStyle={{
-        backgroundColor: neutral17,
-        justifyContent: "space-between",
-        alignItems: "flex-start",
-        padding: 12,
-      }}
+    <Box
+      fillGradient={
+        completed ? { colors: ["#9C4CEA", "#336AFF", "#26C5FB"] } : undefined
+      }
+      style={[
+        {
+          width,
+          backgroundColor: completed ? undefined : neutral17,
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+          borderColor: neutral33,
+          padding: 12,
+          borderWidth: 1,
+        },
+        style,
+      ]}
     >
       <SVG width={32} height={32} source={burnSVG} />
       <SpacerColumn size={1} />
@@ -42,6 +48,6 @@ export const QuestCard: React.FC<{
       >
         {label}
       </BrandText>
-    </TertiaryBox>
+    </Box>
   );
 }, isEqual);

--- a/packages/components/cards/WalletStatusCard.tsx
+++ b/packages/components/cards/WalletStatusCard.tsx
@@ -9,14 +9,14 @@ import { tinyAddress } from "../../utils/text";
 import { BrandText } from "../BrandText";
 import { NetworkIcon } from "../NetworkIcon";
 import { SuccessBadge } from "../badges/SuccessBadge";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 export const WalletStatusCard: React.FC = () => {
   const wallet = useSelectedWallet();
   const selectedNetworkInfo = getNetwork(wallet?.networkId);
 
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       fullWidth
       mainContainerStyle={{
         backgroundColor: neutral17,
@@ -43,6 +43,6 @@ export const WalletStatusCard: React.FC = () => {
       </View>
 
       <SuccessBadge label="connected" />
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };

--- a/packages/components/carousels/CollectionsCarouselHeader.tsx
+++ b/packages/components/carousels/CollectionsCarouselHeader.tsx
@@ -21,7 +21,7 @@ import { BrandText } from "../BrandText";
 import { OptimizedImage } from "../OptimizedImage";
 import { SVG } from "../SVG";
 import { Section } from "../Section";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { PrimaryButton } from "../buttons/PrimaryButton";
 import { GradientText } from "../gradientText";
 
@@ -88,7 +88,7 @@ const CarouselCollectionItem: React.FC<{
       </View>
 
       {/* Right container */}
-      <TertiaryBox style={{ marginBottom: 40 }}>
+      <LegacyTertiaryBox style={{ marginBottom: 40 }}>
         {collection.imageUri ? (
           <OptimizedImage
             sourceURI={collection.imageUri}
@@ -103,7 +103,7 @@ const CarouselCollectionItem: React.FC<{
         ) : (
           <ActivityIndicator size="large" style={{ margin: 40 }} />
         )}
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </View>
   );
 };

--- a/packages/components/collapsable/CollapsableSection.tsx
+++ b/packages/components/collapsable/CollapsableSection.tsx
@@ -21,7 +21,7 @@ import { fontSemibold14 } from "../../utils/style/fonts";
 import { layout } from "../../utils/style/layout";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { SpacerRow } from "../spacer";
 
 type CollapsableSectionProps = {
@@ -75,7 +75,7 @@ export const CollapsableSection: React.FC<CollapsableSectionProps> = ({
   };
 
   return (
-    <TertiaryBox fullWidth>
+    <LegacyTertiaryBox fullWidth>
       <Pressable onPress={toggleExpansion} style={styles.header}>
         <View style={styles.rowWithCenter}>
           <SVG source={icon} width={14} height={14} color={secondaryColor} />
@@ -107,7 +107,7 @@ export const CollapsableSection: React.FC<CollapsableSectionProps> = ({
           {children}
         </View>
       </Animated.View>
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };
 

--- a/packages/components/connectWallet/ConnectWalletModal.tsx
+++ b/packages/components/connectWallet/ConnectWalletModal.tsx
@@ -39,7 +39,6 @@ export const ConnectWalletModal: React.FC<ConnectWalletProps> = ({
       visible={visible}
       hideMainSeparator
       width={457}
-      noBrokenCorners
     >
       <ConnectKeplrButton onDone={onClose} />
       <SpacerColumn size={1.5} />

--- a/packages/components/dao/DAOMembers.tsx
+++ b/packages/components/dao/DAOMembers.tsx
@@ -125,7 +125,6 @@ const AddMembersModal: React.FC<{
       label="Add members to DAO"
       onClose={onClose}
       scrollable
-      noBrokenCorners
     >
       <View
         style={{

--- a/packages/components/dao/GnoDemo.tsx
+++ b/packages/components/dao/GnoDemo.tsx
@@ -341,7 +341,6 @@ const GnoCreateProposal: React.FC<{ daoId: string | undefined }> = ({
       <ModalBase
         label={`Create proposal on ${daoAddress}`}
         visible={modalVisible}
-        noBrokenCorners
         onClose={() => setModalVisible(false)}
       >
         <TextInputCustom

--- a/packages/components/fileUploader/FileUploader.tsx
+++ b/packages/components/fileUploader/FileUploader.tsx
@@ -16,7 +16,7 @@ import { layout } from "../../utils/style/layout";
 import { BrandText } from "../BrandText";
 import { DeleteButton } from "../FilePreview/DeleteButton";
 import { SVG } from "../SVG";
-import { PrimaryBox } from "../boxes/PrimaryBox";
+import { LegacyPrimaryBox } from "../boxes/LegacyPrimaryBox";
 import { GradientText } from "../gradientText";
 import { Label } from "../inputs/TextInputCustom";
 
@@ -65,7 +65,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
               />
             </>
           ) : (
-            <PrimaryBox
+            <LegacyPrimaryBox
               noBrokenCorners
               fullWidth
               colors={[
@@ -111,7 +111,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
                   </BrandText>
                 </View>
               </View>
-            </PrimaryBox>
+            </LegacyPrimaryBox>
           )}
         </div>
       </TouchableOpacity>

--- a/packages/components/fileUploader/FileUploader.web.tsx
+++ b/packages/components/fileUploader/FileUploader.web.tsx
@@ -18,7 +18,7 @@ import { layout } from "../../utils/style/layout";
 import { BrandText } from "../BrandText";
 import { DeleteButton } from "../FilePreview/DeleteButton";
 import { SVG } from "../SVG";
-import { PrimaryBox } from "../boxes/PrimaryBox";
+import { LegacyPrimaryBox } from "../boxes/LegacyPrimaryBox";
 import { GradientText } from "../gradientText";
 import { Label } from "../inputs/TextInputCustom";
 
@@ -164,7 +164,7 @@ export const FileUploader: FC<FileUploaderProps> = ({
                 />
               </>
             ) : (
-              <PrimaryBox
+              <LegacyPrimaryBox
                 noBrokenCorners
                 fullWidth
                 colors={[
@@ -218,7 +218,7 @@ export const FileUploader: FC<FileUploaderProps> = ({
                     accept={mimeTypes?.join(",")}
                   />
                 </View>
-              </PrimaryBox>
+              </LegacyPrimaryBox>
             )}
           </div>
         </TouchableOpacity>

--- a/packages/components/footers/Footer.tsx
+++ b/packages/components/footers/Footer.tsx
@@ -16,11 +16,11 @@ import logoSVG from "../../../assets/logos/logo.svg";
 import { secondaryColor } from "../../utils/style/colors";
 import { layout } from "../../utils/style/layout";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 const FooterSocialNetworks: React.FC = () => {
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       mainContainerStyle={{ padding: layout.spacing_x1, flexDirection: "row" }}
       style={{ marginBottom: layout.contentSpacing }}
     >
@@ -30,7 +30,7 @@ const FooterSocialNetworks: React.FC = () => {
           Linking.openURL("https://www.coingecko.com/en/coins/teritori")
         }
       >
-        <TertiaryBox
+        <LegacyTertiaryBox
           mainContainerStyle={{
             borderColor: secondaryColor,
             borderRadius: 12,
@@ -38,14 +38,14 @@ const FooterSocialNetworks: React.FC = () => {
           }}
         >
           <SVG source={coingecko} width={20} height={20} />
-        </TertiaryBox>
+        </LegacyTertiaryBox>
       </TouchableOpacity>
 
       <TouchableOpacity
         style={{ marginRight: layout.spacing_x1 }}
         onPress={() => Linking.openURL("https://twitter.com/TeritoriNetwork")}
       >
-        <TertiaryBox
+        <LegacyTertiaryBox
           mainContainerStyle={{
             borderColor: secondaryColor,
             borderRadius: 12,
@@ -53,14 +53,14 @@ const FooterSocialNetworks: React.FC = () => {
           }}
         >
           <SVG source={XtwitterSVG} width={20} height={20} />
-        </TertiaryBox>
+        </LegacyTertiaryBox>
       </TouchableOpacity>
 
       <TouchableOpacity
         style={{ marginRight: layout.spacing_x1 }}
         onPress={() => Linking.openURL("https://discord.gg/teritori")}
       >
-        <TertiaryBox
+        <LegacyTertiaryBox
           mainContainerStyle={{
             borderColor: secondaryColor,
             borderRadius: 12,
@@ -68,13 +68,13 @@ const FooterSocialNetworks: React.FC = () => {
           }}
         >
           <SVG source={discordSVG} width={20} height={20} />
-        </TertiaryBox>
+        </LegacyTertiaryBox>
       </TouchableOpacity>
 
       <TouchableOpacity
         onPress={() => Linking.openURL("https://medium.com/teritori/")}
       >
-        <TertiaryBox
+        <LegacyTertiaryBox
           mainContainerStyle={{
             borderColor: secondaryColor,
             borderRadius: 12,
@@ -82,9 +82,9 @@ const FooterSocialNetworks: React.FC = () => {
           }}
         >
           <SVG source={mediumSVG} width={20} height={20} />
-        </TertiaryBox>
+        </LegacyTertiaryBox>
       </TouchableOpacity>
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };
 

--- a/packages/components/hub/ProfileButton.tsx
+++ b/packages/components/hub/ProfileButton.tsx
@@ -156,9 +156,8 @@ const RegisterGnoNameModal: React.FC<{
     <ModalBase
       label="Register Gno name"
       visible={visible}
-      noBrokenCorners
       onClose={onClose}
-      contentStyle={{ minWidth: 400 }}
+      boxStyle={{ minWidth: 400 }}
     >
       <BrandText style={fontSemibold14}>
         <BrandText style={[fontSemibold14, { color: neutral77 }]}>

--- a/packages/components/inputs/TextInputCustom.tsx
+++ b/packages/components/inputs/TextInputCustom.tsx
@@ -44,7 +44,7 @@ import { layout } from "../../utils/style/layout";
 import { BrandText } from "../BrandText";
 import { ErrorText } from "../ErrorText";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { CustomPressable } from "../buttons/CustomPressable";
 import { SpacerColumn, SpacerRow } from "../spacer";
 
@@ -248,7 +248,7 @@ export const TextInputCustom = <T extends FieldValues>({
           <SpacerColumn size={1.5} />
         </>
       )}
-      <TertiaryBox
+      <LegacyTertiaryBox
         squaresBackgroundColor={squaresBackgroundColor}
         style={style}
         mainContainerStyle={[
@@ -299,7 +299,7 @@ export const TextInputCustom = <T extends FieldValues>({
             <>{children}</>
           )}
         </View>
-      </TertiaryBox>
+      </LegacyTertiaryBox>
       <ErrorText>{error || fieldError}</ErrorText>
     </CustomPressable>
   );

--- a/packages/components/mediaPlayer/TogglePlayerButton.tsx
+++ b/packages/components/mediaPlayer/TogglePlayerButton.tsx
@@ -7,7 +7,7 @@ import { useIsMobile } from "../../hooks/useIsMobile";
 import { secondaryColor } from "../../utils/style/colors";
 import { layout } from "../../utils/style/layout";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 export const TogglePlayerButton: FC = () => {
   const isMobile = useIsMobile();
@@ -19,7 +19,7 @@ export const TogglePlayerButton: FC = () => {
         setIsMediaPlayerOpen((isMediaPlayerOpen) => !isMediaPlayerOpen)
       }
     >
-      <TertiaryBox
+      <LegacyTertiaryBox
         noBrokenCorners
         mainContainerStyle={{
           flexDirection: "row",
@@ -36,7 +36,7 @@ export const TogglePlayerButton: FC = () => {
             color={secondaryColor}
           />
         </View>
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/modals/ModalBase.tsx
+++ b/packages/components/modals/ModalBase.tsx
@@ -24,6 +24,7 @@ import { layout, RESPONSIVE_BREAKPOINT_S } from "../../utils/style/layout";
 import { modalMarginPadding } from "../../utils/style/modals";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
+import { BoxStyle } from "../boxes/Box";
 import { TertiaryBox } from "../boxes/TertiaryBox";
 import { SeparatorGradient } from "../separators/SeparatorGradient";
 import { SpacerColumn } from "../spacer";
@@ -41,9 +42,8 @@ type ModalBaseProps = {
   childrenBottom?: JSX.Element | JSX.Element[];
   hideMainSeparator?: boolean;
   description?: string;
-  noBrokenCorners?: boolean;
   scrollable?: boolean;
-  contentStyle?: StyleProp<ViewStyle>;
+  boxStyle?: StyleProp<BoxStyle>;
   containerStyle?: StyleProp<ViewStyle>;
   childrenContainerStyle?: StyleProp<ViewStyle>;
   closeButtonStyle?: StyleProp<ViewStyle>;
@@ -80,11 +80,10 @@ const ModalBase: React.FC<ModalBaseProps> = ({
   hideMainSeparator,
   description,
   scrollable,
-  contentStyle,
+  boxStyle,
   containerStyle,
   childrenContainerStyle,
   onBackPress,
-  noBrokenCorners,
   closeButtonStyle,
   verticalPosition = "center",
   closeOnBlur,
@@ -105,7 +104,12 @@ const ModalBase: React.FC<ModalBaseProps> = ({
 
   return (
     <Modal
-      style={{ flex: 1, alignItems: "center", justifyContent: "center" }}
+      style={{
+        flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
+        margin: 0,
+      }}
       animationType="fade"
       transparent
       visible={visible}
@@ -143,31 +147,16 @@ const ModalBase: React.FC<ModalBaseProps> = ({
       >
         {/*------ Modal main container */}
         <TertiaryBox
-          fullWidth={windowWidth < RESPONSIVE_BREAKPOINT_S}
-          width={windowWidth < RESPONSIVE_BREAKPOINT_S ? undefined : width}
           style={[
-            { margin: "auto" },
+            {
+              margin: "auto",
+              width: windowWidth < RESPONSIVE_BREAKPOINT_S ? "100%" : width,
+              alignItems: "flex-start",
+            },
             verticalPosition === "top" && { marginTop: 0 },
             verticalPosition === "bottom" && { marginBottom: 0 },
+            boxStyle,
           ]}
-          mainContainerStyle={[
-            {
-              alignItems: "flex-start",
-              backgroundColor: "#000000",
-            },
-            verticalPosition === "top" && {
-              borderTopEndRadius: 0,
-              borderTopStartRadius: 0,
-              borderTopWidth: 0,
-            },
-            verticalPosition === "bottom" && {
-              borderBottomEndRadius: 0,
-              borderBottomStartRadius: 0,
-              borderBottomWidth: 0,
-            },
-            contentStyle,
-          ]}
-          noBrokenCorners={noBrokenCorners}
         >
           {/*------ Modal header */}
           <View

--- a/packages/components/modals/ModalDisclaimer.tsx
+++ b/packages/components/modals/ModalDisclaimer.tsx
@@ -3,7 +3,7 @@ import { Modal, View } from "react-native";
 
 import { modalMarginPadding } from "../../utils/style/modals";
 import { BrandText } from "../BrandText";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { SeparatorGradient } from "../separators/SeparatorGradient";
 
 // TODO: Simplify this component (Useless childrenBottom ?. Better to let the parent totally decides which children to use ? Used in WalletManager.tsx, be careful !)
@@ -34,7 +34,7 @@ const ModalBaseTest: React.FC<{
         }}
       >
         {/*------ Modal main container */}
-        <TertiaryBox
+        <LegacyTertiaryBox
           width={width}
           style={{ margin: "auto" }}
           mainContainerStyle={{
@@ -76,7 +76,7 @@ const ModalBaseTest: React.FC<{
           )}
           {/*------- Modal bottom content */}
           {childrenBottom}
-        </TertiaryBox>
+        </LegacyTertiaryBox>
       </View>
     </Modal>
   );

--- a/packages/components/modals/NetworksListModal.tsx
+++ b/packages/components/modals/NetworksListModal.tsx
@@ -29,7 +29,7 @@ import { modalMarginPadding } from "../../utils/style/modals";
 import { BrandText } from "../BrandText";
 import { EmptyList } from "../EmptyList";
 import { NetworkIcon } from "../NetworkIcon";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { TextInputCustom } from "../inputs/TextInputCustom";
 import { SpacerColumn, SpacerRow } from "../spacer";
 
@@ -43,7 +43,7 @@ export const NetworksListModal: FC<{
       label="Manage Networks"
       visible={isVisible}
       onClose={onClose}
-      contentStyle={{ minWidth: 360, paddingBottom: modalMarginPadding }}
+      boxStyle={{ minWidth: 360, paddingBottom: modalMarginPadding }}
     >
       <NetworksSettings />
     </ModalBase>
@@ -97,7 +97,10 @@ const NetworkSettingsItem: FC<{ networkId: string }> = memo(({ networkId }) => {
   const n = getNetwork(networkId);
   if (!n) return null;
   return (
-    <TertiaryBox fullWidth mainContainerStyle={{ padding: layout.spacing_x1 }}>
+    <LegacyTertiaryBox
+      fullWidth
+      mainContainerStyle={{ padding: layout.spacing_x1 }}
+    >
       <TouchableOpacity
         onPress={() => {
           dispatch(toggleNetwork({ networkId }));
@@ -130,6 +133,6 @@ const NetworkSettingsItem: FC<{ networkId: string }> = memo(({ networkId }) => {
           value={state}
         />
       </TouchableOpacity>
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 });

--- a/packages/components/modals/transaction/TransactionPaymentModal.tsx
+++ b/packages/components/modals/transaction/TransactionPaymentModal.tsx
@@ -55,13 +55,7 @@ export const TransactionPaymentModal: React.FC<{
   }
 
   return (
-    <ModalBase
-      visible={visible}
-      onClose={onClose}
-      width={372}
-      label={label}
-      noBrokenCorners
-    >
+    <ModalBase visible={visible} onClose={onClose} width={372} label={label}>
       <View>
         {/*==== Text*/}
         <View style={{ flexDirection: "row", marginBottom: 16 }}>

--- a/packages/components/modals/transaction/TransactionPendingModal.tsx
+++ b/packages/components/modals/transaction/TransactionPendingModal.tsx
@@ -24,7 +24,6 @@ export const TransactionPendingModal: React.FC<{
       onClose={onClose}
       width={372}
       label="Follow steps"
-      noBrokenCorners
     >
       <View style={{ flexDirection: "row", marginBottom: 24 }}>
         <ActivityIndicator style={{ marginRight: 16 }} size="large" />

--- a/packages/components/modals/transaction/TransactionSuccessModal.tsx
+++ b/packages/components/modals/transaction/TransactionSuccessModal.tsx
@@ -47,7 +47,6 @@ export const TransactionSuccessModal: React.FC<{
       onClose={onClose}
       width={width}
       label="Success"
-      noBrokenCorners
     >
       <>{image ? <Image source={image} /> : null}</>
       {textComponent}

--- a/packages/components/navigation/components/CartIconButtonBadge.tsx
+++ b/packages/components/navigation/components/CartIconButtonBadge.tsx
@@ -17,7 +17,7 @@ import {
 import { fontMedium14, fontSemibold12 } from "../../../utils/style/fonts";
 import { layout } from "../../../utils/style/layout";
 import { BrandText } from "../../BrandText";
-import { TertiaryBox } from "../../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../boxes/LegacyTertiaryBox";
 import { SpacerRow } from "../../spacer";
 
 export const CartIconButtonBadge: React.FC<{
@@ -40,7 +40,7 @@ export const CartIconButtonBadge: React.FC<{
   return selected.length > 0 ? (
     <View style={style}>
       <TouchableOpacity onPress={handleShowCart}>
-        <TertiaryBox
+        <LegacyTertiaryBox
           noBrokenCorners={isMobile}
           mainContainerStyle={{
             flexDirection: "row",
@@ -64,7 +64,7 @@ export const CartIconButtonBadge: React.FC<{
           >
             {selected.length}
           </BrandText>
-        </TertiaryBox>
+        </LegacyTertiaryBox>
       </TouchableOpacity>
     </View>
   ) : null;

--- a/packages/components/nftDetails/NFTMainInfo.tsx
+++ b/packages/components/nftDetails/NFTMainInfo.tsx
@@ -27,7 +27,7 @@ import { NFTInfo } from "../../utils/types/nft";
 import { BrandText } from "../BrandText";
 import { ImageWithTextInsert } from "../ImageWithTextInsert";
 import { ActivityTable } from "../activity/ActivityTable";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { NFTCancelListingCard } from "../cards/NFTCancelListingCard";
 import { NFTPriceBuyCard } from "../cards/NFTPriceBuyCard";
 import { NFTSellCard } from "../cards/NFTSellCard";
@@ -231,7 +231,7 @@ export const NFTMainInfo: React.FC<{
         }}
       >
         {/*---- Image NFT */}
-        <TertiaryBox
+        <LegacyTertiaryBox
           width={isMobile && width < 464 ? width : 464}
           height={isMobile && width < 464 ? width : 464}
           style={{
@@ -245,7 +245,7 @@ export const NFTMainInfo: React.FC<{
             size={isMobile && width < 464 ? width : 462}
             style={{ borderRadius: 8 }}
           />
-        </TertiaryBox>
+        </LegacyTertiaryBox>
         {/*---- Info NFT */}
         <View style={{ maxWidth: isMobile && width < 600 ? width : 600 }}>
           <BrandText style={[fontSemibold28, { marginBottom: 12 }]}>

--- a/packages/components/nfts/NFTView.tsx
+++ b/packages/components/nfts/NFTView.tsx
@@ -1,12 +1,6 @@
 import { isEqual } from "lodash";
 import React, { RefObject, memo, useMemo, useRef, useState } from "react";
-import {
-  ViewStyle,
-  View,
-  StyleProp,
-  StyleSheet,
-  Pressable,
-} from "react-native";
+import { View, StyleProp, StyleSheet, Pressable } from "react-native";
 import { useSelector } from "react-redux";
 
 import { NFTTransferModal } from "./NFTTransferModal";
@@ -45,6 +39,7 @@ import { ImageWithTextInsert } from "../ImageWithTextInsert";
 import { NetworkIcon } from "../NetworkIcon";
 import { OmniLink } from "../OmniLink";
 import { SVG } from "../SVG";
+import { BoxStyle } from "../boxes/Box";
 import { TertiaryBox } from "../boxes/TertiaryBox";
 import { SecondaryButton } from "../buttons/SecondaryButton";
 import { UserAvatarWithFrame } from "../images/AvatarWithFrame";
@@ -54,7 +49,7 @@ import { SpacerColumn, SpacerRow } from "../spacer";
 
 export const NFTView: React.FC<{
   data: NFT;
-  style?: StyleProp<Omit<ViewStyle, "width"> & { width?: number }>;
+  style?: StyleProp<Omit<BoxStyle, "width"> & { width?: number }>;
 }> = memo(({ data: nft, style }) => {
   const isMobile = useIsMobile();
   const cardWidth = isMobile ? 220 : 250;
@@ -77,6 +72,12 @@ export const NFTView: React.FC<{
 
   const widthNumber = width || cardWidth;
 
+  const selectedNfts = useSelector(selectSelectedNFTIds);
+  const localSelected = useMemo(
+    () => new Set(selectedNfts).has(nft.id),
+    [nft.id, selectedNfts],
+  );
+
   return (
     <>
       <View
@@ -92,14 +93,22 @@ export const NFTView: React.FC<{
         }}
       >
         <TertiaryBox
-          key={nft.name}
-          width={widthNumber}
-          style={styleWithoutMargins}
+          style={[
+            styleWithoutMargins,
+            {
+              width: widthNumber,
+              padding: 0,
+            },
+            localSelected && {
+              backgroundColor: neutral22,
+            },
+          ]}
         >
           <NFTViewContent
             nft={nft}
             dropdownRef={dropdownRef}
             mobileMode={isMobile}
+            localSelected={localSelected}
           />
         </TertiaryBox>
       </View>
@@ -111,14 +120,10 @@ const NFTViewContent: React.FC<{
   nft: NFT;
   dropdownRef: RefObject<View>;
   mobileMode: boolean;
-}> = memo(({ nft, dropdownRef, mobileMode }) => {
+  localSelected: boolean;
+}> = memo(({ nft, dropdownRef, mobileMode, localSelected }) => {
   const insideMargin = layout.spacing_x2;
   const selectedWallet = useSelectedWallet();
-  const selectedNfts = useSelector(selectSelectedNFTIds);
-  const localSelected = useMemo(
-    () => new Set(selectedNfts).has(nft.id),
-    [nft.id, selectedNfts],
-  );
   const dispatch = useAppDispatch();
   const handleClick = (nft: NFT, selected: boolean) => {
     if (mobileMode) return; // disable cart on mobile
@@ -141,7 +146,6 @@ const NFTViewContent: React.FC<{
           paddingHorizontal: insideMargin,
           zIndex: 1000,
           borderTopRightRadius: 7,
-          backgroundColor: localSelected ? neutral22 : neutral00,
         }}
         onPress={() => {
           handleClick(nft, localSelected);
@@ -360,7 +364,6 @@ const NFTViewFooter: React.FC<{ nft: NFT; localSelected: boolean }> = memo(
         style={{
           borderTopWidth: 1,
           borderTopColor: neutral33,
-          backgroundColor: localSelected ? neutral22 : neutral00,
           height: 69,
           paddingHorizontal: 16,
           flexDirection: "row",

--- a/packages/components/socialFeed/NewsFeed/NewsFeedInput.tsx
+++ b/packages/components/socialFeed/NewsFeed/NewsFeedInput.tsx
@@ -67,7 +67,7 @@ import FlexRow from "../../FlexRow";
 import { IconBox } from "../../IconBox";
 import { OmniLink } from "../../OmniLink";
 import { SVG } from "../../SVG";
-import { PrimaryBox } from "../../boxes/PrimaryBox";
+import { LegacyPrimaryBox } from "../../boxes/LegacyPrimaryBox";
 import { PrimaryButton } from "../../buttons/PrimaryButton";
 import { SecondaryButtonOutline } from "../../buttons/SecondaryButtonOutline";
 import { FileUploader } from "../../fileUploader";
@@ -291,7 +291,7 @@ export const NewsFeedInput = React.forwardRef<
             onClose={() => setNotEnoughFundModal(false)}
           />
         )}
-        <PrimaryBox
+        <LegacyPrimaryBox
           fullWidth
           style={{
             zIndex: 9,
@@ -417,7 +417,7 @@ export const NewsFeedInput = React.forwardRef<
               }
             }}
           />
-        </PrimaryBox>
+        </LegacyPrimaryBox>
         <View
           style={{
             backgroundColor: neutral17,
@@ -620,7 +620,6 @@ export const NewsFeedInput = React.forwardRef<
                 text={
                   daoId ? "Propose" : type === "comment" ? "Comment" : "Publish"
                 }
-                squaresBackgroundColor={neutral17}
                 onPress={handleSubmit(processSubmit)}
               />
             </View>

--- a/packages/components/socialFeed/RichText/Toolbar/ToolbarContainer.tsx
+++ b/packages/components/socialFeed/RichText/Toolbar/ToolbarContainer.tsx
@@ -6,11 +6,11 @@ import {
   gradientColorTurquoise,
 } from "../../../../utils/style/colors";
 import { layout } from "../../../../utils/style/layout";
-import { PrimaryBox } from "../../../boxes/PrimaryBox";
+import { LegacyPrimaryBox } from "../../../boxes/LegacyPrimaryBox";
 
 export const ToolbarContainer: FC<{ children: ReactNode }> = ({ children }) => {
   return (
-    <PrimaryBox
+    <LegacyPrimaryBox
       fullWidth
       colors={[
         gradientColorDarkerBlue,
@@ -26,6 +26,6 @@ export const ToolbarContainer: FC<{ children: ReactNode }> = ({ children }) => {
       }}
     >
       {children}
-    </PrimaryBox>
+    </LegacyPrimaryBox>
   );
 };

--- a/packages/components/sorts/FilterButton.tsx
+++ b/packages/components/sorts/FilterButton.tsx
@@ -13,7 +13,7 @@ import { useAppDispatch } from "../../store/store";
 import { secondaryColor } from "../../utils/style/colors";
 import { layout } from "../../utils/style/layout";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 export const FilterButton: React.FC<{
   style?: StyleProp<ViewStyle>;
@@ -28,7 +28,7 @@ export const FilterButton: React.FC<{
 
   return (
     <TouchableOpacity onPress={handlePress} style={style}>
-      <TertiaryBox
+      <LegacyTertiaryBox
         noBrokenCorners
         height={48}
         width={showChevron ? undefined : 48}
@@ -50,7 +50,7 @@ export const FilterButton: React.FC<{
             color={secondaryColor}
           />
         )}
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/sorts/SearchInput.tsx
+++ b/packages/components/sorts/SearchInput.tsx
@@ -5,7 +5,7 @@ import searchSVG from "../../../assets/icons/search.svg";
 import { fontMedium14 } from "../../utils/style/fonts";
 import { layout } from "../../utils/style/layout";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 export const SearchInput: React.FC<{
   style?: StyleProp<ViewStyle>;
@@ -13,7 +13,7 @@ export const SearchInput: React.FC<{
   handleChangeText?: (e: string) => void;
 }> = ({ handleChangeText, borderRadius, style }) => {
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       style={style}
       height={40}
       mainContainerStyle={{
@@ -34,7 +34,7 @@ export const SearchInput: React.FC<{
         placeholderTextColor="#FFFFFF"
         style={textInputStyle}
       />
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };
 

--- a/packages/components/sorts/SortButton.tsx
+++ b/packages/components/sorts/SortButton.tsx
@@ -9,7 +9,7 @@ import { neutral11, secondaryColor } from "../../utils/style/colors";
 import { fontSemibold14 } from "../../utils/style/fonts";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 export const SortButton: React.FC<{
   sortDirection: SortDirection;
@@ -34,7 +34,7 @@ export const SortButton: React.FC<{
 
   return (
     <TouchableOpacity onPress={handlePress} style={style}>
-      <TertiaryBox
+      <LegacyTertiaryBox
         fullWidth
         mainContainerStyle={[
           {
@@ -74,7 +74,7 @@ export const SortButton: React.FC<{
           style={{ marginLeft: 8 }}
           color={secondaryColor}
         />
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/teritoriNameService/FlowCard.tsx
+++ b/packages/components/teritoriNameService/FlowCard.tsx
@@ -7,7 +7,7 @@ import { neutral00, neutral22, neutral77 } from "../../utils/style/colors";
 import { fontSemibold14, fontSemibold20 } from "../../utils/style/fonts";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 export const FlowCard: React.FC<{
   label: string;
@@ -23,7 +23,7 @@ export const FlowCard: React.FC<{
       disabled={disabled}
       style={[{ flex: 1 }, style]}
     >
-      <TertiaryBox
+      <LegacyTertiaryBox
         height={224}
         fullWidth
         mainContainerStyle={{
@@ -65,7 +65,7 @@ export const FlowCard: React.FC<{
         >
           <SVG source={chevronRightSVG} width={16} />
         </View>
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/components/teritoriNameService/NameData.tsx
+++ b/packages/components/teritoriNameService/NameData.tsx
@@ -5,7 +5,7 @@ import { neutral17, neutral77 } from "../../utils/style/colors";
 import { imageDisplayLabel, prettyTokenData } from "../../utils/teritori";
 import { BrandText } from "../BrandText";
 import { ExternalLink } from "../ExternalLink";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 export const NameData: React.FC<{
   token: any;
@@ -15,7 +15,7 @@ export const NameData: React.FC<{
   const width = 396;
 
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       width={width}
       mainContainerStyle={[
         {
@@ -82,6 +82,6 @@ export const NameData: React.FC<{
       ) : (
         <BrandText>Loading</BrandText>
       )}
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };

--- a/packages/components/teritoriNameService/NameDataForm.tsx
+++ b/packages/components/teritoriNameService/NameDataForm.tsx
@@ -214,7 +214,6 @@ export const NameDataForm: React.FC<{
         disabled={disabled}
         onPress={handlePressBtn}
         style={{ marginTop: 8, alignSelf: "center" }}
-        squaresBackgroundColor={neutral17}
         loader
       />
     </View>

--- a/packages/components/teritoriNameService/NameStatus.tsx
+++ b/packages/components/teritoriNameService/NameStatus.tsx
@@ -5,7 +5,7 @@ import mintedSVG from "../../../assets/icons/minted.svg";
 import { errorColor, neutral17, successColor } from "../../utils/style/colors";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 
 // A custom TextInput. You can add children (Ex: An icon or a small container)
 export const NameStatus: React.FC<{
@@ -13,7 +13,7 @@ export const NameStatus: React.FC<{
   hasError?: boolean;
 }> = ({ available, hasError }) => {
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       mainContainerStyle={{
         flexDirection: "row",
         justifyContent: "flex-start",
@@ -36,6 +36,6 @@ export const NameStatus: React.FC<{
       <BrandText style={{ fontSize: 14, marginLeft: 4 }}>
         {hasError ? "error" : available ? "available" : "minted"}
       </BrandText>
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };

--- a/packages/components/toasts/ToastError.tsx
+++ b/packages/components/toasts/ToastError.tsx
@@ -5,6 +5,7 @@ import warningSVG from "../../../assets/icons/warning.svg";
 import { errorColor, neutral11, neutral77 } from "../../utils/style/colors";
 import { BrandText } from "../BrandText";
 import { SVG } from "../SVG";
+import { Box } from "../boxes/Box";
 import { SpacerRow } from "../spacer";
 
 export const ToastError: React.FC<{
@@ -18,13 +19,6 @@ export const ToastError: React.FC<{
     <TouchableOpacity
       onPress={onPress}
       style={{
-        flexDirection: "row",
-        alignItems: "center",
-        backgroundColor: neutral11,
-        borderColor: errorColor,
-        borderRadius: 8,
-        borderWidth: 1,
-        borderStyle: "solid",
         maxWidth: width,
         width,
         height: "auto",
@@ -34,15 +28,30 @@ export const ToastError: React.FC<{
         zIndex: 999,
       }}
     >
-      <SpacerRow size={3} />
-      <SVG width={24} height={24} source={warningSVG} />
-      <SpacerRow size={3} />
-      <View style={{ maxWidth: 287, marginVertical: 12 }}>
-        <BrandText style={{ fontSize: 13, lineHeight: 20 }}>{title}</BrandText>
-        <BrandText style={{ fontSize: 13, lineHeight: 15, color: neutral77 }}>
-          {message}
-        </BrandText>
-      </View>
+      <Box
+        notched
+        style={{
+          width: "100%",
+          height: "100%",
+          flexDirection: "row",
+          alignItems: "center",
+          backgroundColor: neutral11,
+          borderColor: errorColor,
+          borderWidth: 1,
+        }}
+      >
+        <SpacerRow size={3} />
+        <SVG width={24} height={24} source={warningSVG} />
+        <SpacerRow size={3} />
+        <View style={{ maxWidth: 287, marginVertical: 12 }}>
+          <BrandText style={{ fontSize: 13, lineHeight: 20 }}>
+            {title}
+          </BrandText>
+          <BrandText style={{ fontSize: 13, lineHeight: 15, color: neutral77 }}>
+            {message}
+          </BrandText>
+        </View>
+      </Box>
     </TouchableOpacity>
   );
 };

--- a/packages/components/toasts/ToastSuccess.tsx
+++ b/packages/components/toasts/ToastSuccess.tsx
@@ -3,6 +3,7 @@ import { Dimensions, TouchableOpacity, View } from "react-native";
 
 import { neutral11, neutral77, successColor } from "../../utils/style/colors";
 import { BrandText } from "../BrandText";
+import { Box } from "../boxes/Box";
 
 export const ToastSuccess: React.FC<{
   title: string;
@@ -16,13 +17,6 @@ export const ToastSuccess: React.FC<{
     <TouchableOpacity
       onPress={onPress}
       style={{
-        flexDirection: "row",
-        alignItems: "center",
-        backgroundColor: neutral11,
-        borderColor: successColor,
-        borderRadius: 8,
-        borderWidth: 1,
-        borderStyle: "solid",
         width,
         maxWidth: width,
         height: "auto",
@@ -32,29 +26,42 @@ export const ToastSuccess: React.FC<{
         zIndex: 999,
       }}
     >
-      <View
+      <Box
+        notched
         style={{
-          width: width - marginHorizontal * 2,
-          marginVertical: 12,
-          marginHorizontal,
+          flexDirection: "row",
+          alignItems: "center",
+          backgroundColor: neutral11,
+          borderColor: successColor,
+          borderWidth: 1,
+          width: "100%",
+          height: "100%",
         }}
       >
-        <BrandText style={{ fontSize: 13, lineHeight: 20, width: "100%" }}>
-          {title}
-        </BrandText>
-        {message ? (
-          <BrandText
-            style={{
-              fontSize: 13,
-              lineHeight: 15,
-              color: neutral77,
-              width: "100%",
-            }}
-          >
-            {message}
+        <View
+          style={{
+            width: width - marginHorizontal * 2,
+            marginVertical: 12,
+            marginHorizontal,
+          }}
+        >
+          <BrandText style={{ fontSize: 13, lineHeight: 20, width: "100%" }}>
+            {title}
           </BrandText>
-        ) : null}
-      </View>
+          {message ? (
+            <BrandText
+              style={{
+                fontSize: 13,
+                lineHeight: 15,
+                color: neutral77,
+                width: "100%",
+              }}
+            >
+              {message}
+            </BrandText>
+          ) : null}
+        </View>
+      </Box>
     </TouchableOpacity>
   );
 };

--- a/packages/components/user/UserCard.tsx
+++ b/packages/components/user/UserCard.tsx
@@ -35,7 +35,7 @@ import { BrandText } from "../BrandText";
 import { DropdownOption } from "../DropdownOption";
 import { OmniLink } from "../OmniLink";
 import { SVG } from "../SVG";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { UserAvatarWithFrame } from "../images/AvatarWithFrame";
 
 export const UserCard: React.FC<{
@@ -58,7 +58,7 @@ export const UserCard: React.FC<{
   const padding = 16;
   const width = typeof flatStyle.width === "number" ? flatStyle.width : 325;
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       style={style}
       mainContainerStyle={[
         {
@@ -83,7 +83,7 @@ export const UserCard: React.FC<{
         <BrandText
           style={[
             fontSemibold12,
-            { lineHeight: 14, marginBottom: 8, width: width - 2 * padding }, // FIXME: we have to set a fixed width because TertiaryBox is broken
+            { lineHeight: 14, marginBottom: 8, width: width - 2 * padding }, // FIXME: we have to set a fixed width because LegacyTertiaryBox is broken
           ]}
           numberOfLines={1}
         >
@@ -176,7 +176,7 @@ export const UserCard: React.FC<{
           ]}
         />
       </View>
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };
 

--- a/packages/components/userPublicProfile/UPPIntro.tsx
+++ b/packages/components/userPublicProfile/UPPIntro.tsx
@@ -22,7 +22,7 @@ import { BrandText } from "../BrandText";
 import { useCopyToClipboard } from "../CopyToClipboard";
 import { CopyToClipboardSecondary } from "../CopyToClipboardSecondary";
 import { OptimizedImage } from "../OptimizedImage";
-import { TertiaryBox } from "../boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../boxes/LegacyTertiaryBox";
 import { SecondaryButtonOutline } from "../buttons/SecondaryButtonOutline";
 import { SocialButton } from "../buttons/SocialButton";
 import { SocialButtonSecondary } from "../buttons/SocialButtonSecondary";
@@ -42,7 +42,7 @@ export const UPPIntro: React.FC<{
 
   return (
     <>
-      <TertiaryBox
+      <LegacyTertiaryBox
         height={320}
         noBrokenCorners={windowWidth < RESPONSIVE_BREAKPOINT_S}
         mainContainerStyle={
@@ -129,7 +129,7 @@ export const UPPIntro: React.FC<{
           }}
           size="XL"
         />
-      </TertiaryBox>
+      </LegacyTertiaryBox>
       <View
         style={{
           width: "100%",
@@ -173,7 +173,7 @@ export const UPPIntro: React.FC<{
           </BrandText>
         </View>
         {/* Stats and public address */}
-        <TertiaryBox mainContainerStyle={{ padding: 16 }}>
+        <LegacyTertiaryBox mainContainerStyle={{ padding: 16 }}>
           <View
             style={{
               flexDirection: "row",
@@ -206,7 +206,7 @@ export const UPPIntro: React.FC<{
             text={userAddress}
             networkIcon={network?.id}
           />
-        </TertiaryBox>
+        </LegacyTertiaryBox>
       </View>
     </>
   );

--- a/packages/screens/DAppStore/components/DAppBox.tsx
+++ b/packages/screens/DAppStore/components/DAppBox.tsx
@@ -1,24 +1,22 @@
 import React, { useEffect, useState } from "react";
-import {
-  Pressable,
-  StyleProp,
-  useWindowDimensions,
-  View,
-  ViewStyle,
-} from "react-native";
+import { Pressable, StyleProp, useWindowDimensions, View } from "react-native";
 import { useSelector } from "react-redux";
 
 import { CheckboxDappStore } from "./CheckboxDappStore";
 import { BrandText } from "../../../components/BrandText";
 import { SVGorImageIcon } from "../../../components/SVG/SVGorImageIcon";
-import { SecondaryBox } from "../../../components/boxes/SecondaryBox";
-import { TertiaryBox } from "../../../components/boxes/TertiaryBox";
+import { Box, BoxStyle } from "../../../components/boxes/Box";
 import {
   selectCheckedApps,
   setCheckedApp,
 } from "../../../store/slices/dapps-store";
 import { useAppDispatch } from "../../../store/store";
-import { neutral00, neutral17, neutral77 } from "../../../utils/style/colors";
+import {
+  neutral00,
+  neutral17,
+  neutral33,
+  neutral77,
+} from "../../../utils/style/colors";
 import { fontSemibold13, fontSemibold14 } from "../../../utils/style/fonts";
 import { layout } from "../../../utils/style/layout";
 import { SEPARATOR } from "../query/util";
@@ -26,7 +24,7 @@ import { dAppType } from "../types";
 
 export const DAppBox: React.FC<{
   option: dAppType;
-  style?: StyleProp<ViewStyle>;
+  style?: StyleProp<BoxStyle>;
 }> = ({
   option: { description, groupKey, icon, id, title, alwaysOn },
   style,
@@ -52,36 +50,37 @@ export const DAppBox: React.FC<{
 
   return (
     <Pressable onPress={handleClick} disabled={alwaysOn}>
-      <TertiaryBox
-        height={88}
-        width={isMobile ? width * 0.8 : 306}
-        noBrokenCorners
-        style={style}
-        mainContainerStyle={{
-          alignItems: "center",
-          justifyContent: "space-between",
-          flex: 1,
-          flexDirection: "row",
-          paddingVertical: layout.spacing_x1_5,
-          paddingLeft: layout.spacing_x1_5,
-          paddingRight: layout.spacing_x2_5,
-          borderRadius: 20,
-          backgroundColor: isChecked ? neutral17 : neutral00,
-        }}
+      <Box
+        style={[
+          {
+            alignItems: "center",
+            justifyContent: "space-between",
+            flexDirection: "row",
+            paddingVertical: layout.spacing_x1_5,
+            paddingLeft: layout.spacing_x1_5,
+            paddingRight: layout.spacing_x2_5,
+            borderRadius: 20,
+            borderWidth: 1,
+            borderColor: neutral33,
+            backgroundColor: isChecked ? neutral17 : neutral00,
+            height: 88,
+            width: isMobile ? width * 0.8 : 306,
+          },
+          style,
+        ]}
       >
         <View style={{ flexDirection: "row", alignItems: "center" }}>
-          <SecondaryBox
-            noBrokenCorners
-            mainContainerStyle={{
+          <Box
+            style={{
               backgroundColor: neutral17,
               borderRadius: 12,
               padding: layout.spacing_x1,
+              width: 64,
+              height: 64,
             }}
-            width={64}
-            height={64}
           >
             <SVGorImageIcon icon={icon} iconSize={48} />
-          </SecondaryBox>
+          </Box>
           <View
             style={{
               marginHorizontal: layout.spacing_x2,
@@ -105,7 +104,7 @@ export const DAppBox: React.FC<{
         </View>
 
         {!alwaysOn && <CheckboxDappStore isChecked={isChecked} />}
-      </TertiaryBox>
+      </Box>
     </Pressable>
   );
 };

--- a/packages/screens/DAppStore/components/Dropdown.tsx
+++ b/packages/screens/DAppStore/components/Dropdown.tsx
@@ -7,7 +7,7 @@ import chevronDownSVG from "../../../../assets/icons/chevron-down.svg";
 import chevronUpSVG from "../../../../assets/icons/chevron-up.svg";
 import { BrandText } from "../../../components/BrandText";
 import { SVG } from "../../../components/SVG";
-import { SecondaryBox } from "../../../components/boxes/SecondaryBox";
+import { LegacySecondaryBox } from "../../../components/boxes/LegacySecondaryBox";
 import { useDropdowns } from "../../../context/DropdownsProvider";
 import {
   selectAvailableApps,
@@ -98,7 +98,7 @@ export const DropdownDappsStoreFilter: React.FC = () => {
       </TouchableOpacity>
 
       {isDropdownOpen(dropdownRef) && (
-        <SecondaryBox
+        <LegacySecondaryBox
           noBrokenCorners
           width={248}
           style={{ position: "absolute", top: 29, right: -14 }}
@@ -117,7 +117,7 @@ export const DropdownDappsStoreFilter: React.FC = () => {
               id={option.id}
             />
           ))}
-        </SecondaryBox>
+        </LegacySecondaryBox>
       )}
     </View>
   );

--- a/packages/screens/DAppStore/components/SelectedDraggable.tsx
+++ b/packages/screens/DAppStore/components/SelectedDraggable.tsx
@@ -5,8 +5,7 @@ import { Hoverable } from "react-native-hoverable";
 
 import { BrandText } from "../../../components/BrandText";
 import { SVGorImageIcon } from "../../../components/SVG/SVGorImageIcon";
-import { SecondaryBox } from "../../../components/boxes/SecondaryBox";
-import { TertiaryBox } from "../../../components/boxes/TertiaryBox";
+import { Box } from "../../../components/boxes/Box";
 import { setCheckedApp } from "../../../store/slices/dapps-store";
 import { useAppDispatch } from "../../../store/store";
 import {
@@ -62,15 +61,16 @@ export const SelectedDraggable: React.FC<{
         }}
       >
         <TouchableOpacity onPress={deleteFromList} disabled={alwaysOn}>
-          <SecondaryBox
-            noBrokenCorners
-            mainContainerStyle={{
+          <Box
+            style={{
               backgroundColor: !showTrashIcon
                 ? withAlpha(neutral33, 0.64)
                 : withAlpha(errorColor, 0.14),
+              width: 32,
+              height: 48,
+              alignItems: "center",
+              justifyContent: "center",
             }}
-            width={32}
-            height={48}
           >
             <BrandText
               style={[fontBold12, { color: neutral67 }]}
@@ -78,29 +78,28 @@ export const SelectedDraggable: React.FC<{
             >
               {showTrashIcon ? <TrashIcon size={14} fill="red" /> : index + 1}
             </BrandText>
-          </SecondaryBox>
+          </Box>
         </TouchableOpacity>
       </Hoverable>
 
-      <TertiaryBox
-        height={48}
-        width={256}
-        noBrokenCorners
+      <Box
         style={{
           marginLeft: layout.spacing_x1,
-          ...Platform.select({
-            web: {
-              cursor: "grab",
-            },
-          }),
-        }}
-        mainContainerStyle={{
           flexDirection: "row",
           alignItems: "center",
           justifyContent: "space-between",
           paddingVertical: layout.spacing_x1_5,
           paddingLeft: layout.spacing_x1_5,
           paddingRight: layout.spacing_x2,
+          width: 256,
+          height: 48,
+          borderWidth: 1,
+          borderColor: neutral33,
+          ...Platform.select({
+            web: {
+              cursor: "grab",
+            },
+          }),
         }}
       >
         <View style={{ flexDirection: "row", alignItems: "center" }}>
@@ -115,7 +114,7 @@ export const SelectedDraggable: React.FC<{
         </View>
 
         <Bars3Icon size={24} fill={neutral44} />
-      </TertiaryBox>
+      </Box>
     </Hoverable>
   );
 };

--- a/packages/screens/FeedNewArticle/FeedNewArticleScreen.tsx
+++ b/packages/screens/FeedNewArticle/FeedNewArticleScreen.tsx
@@ -8,7 +8,7 @@ import { BrandText } from "../../components/BrandText";
 import { SVG } from "../../components/SVG";
 import { ScreenContainer } from "../../components/ScreenContainer";
 import { WalletStatusBox } from "../../components/WalletStatusBox";
-import { TertiaryBox } from "../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../components/boxes/LegacyTertiaryBox";
 import { FileUploader } from "../../components/fileUploader";
 import {
   Label,
@@ -220,7 +220,7 @@ export const FeedNewArticleScreen: ScreenFC<"FeedNewArticle"> = () => {
         <WalletStatusBox />
         <SpacerColumn size={3} />
 
-        <TertiaryBox
+        <LegacyTertiaryBox
           fullWidth
           mainContainerStyle={{
             paddingVertical: layout.spacing_x1,
@@ -251,7 +251,7 @@ export const FeedNewArticleScreen: ScreenFC<"FeedNewArticle"> = () => {
                 )} left`
               : `The cost for this Article is ${prettyPublishingFee}`}
           </BrandText>
-        </TertiaryBox>
+        </LegacyTertiaryBox>
 
         <FileUploader
           label="Thumbnail image"

--- a/packages/screens/Governance/GovernanceDetails.tsx
+++ b/packages/screens/Governance/GovernanceDetails.tsx
@@ -9,7 +9,7 @@ import { VictoryPie } from "victory";
 import { ProposalStatus } from "./types";
 import { BrandText } from "../../components/BrandText";
 import { ConfirmationVote } from "../../components/GovernanceBox/ConfirmationVote";
-import { TertiaryBox } from "../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../components/boxes/LegacyTertiaryBox";
 import { PrimaryButton } from "../../components/buttons/PrimaryButton";
 import { SecondaryButton } from "../../components/buttons/SecondaryButton";
 import ModalBase from "../../components/modals/ModalBase";
@@ -403,7 +403,7 @@ export const GovernanceDetails: React.FC<{
         </View>
       </View>
 
-      <TertiaryBox
+      <LegacyTertiaryBox
         width={1240}
         height={196}
         style={{ right: "-0.5%", marginTop: 25 }}
@@ -611,7 +611,7 @@ export const GovernanceDetails: React.FC<{
             onPress={() => activeVote()}
           />
         )}
-      </TertiaryBox>
+      </LegacyTertiaryBox>
 
       {activeConfirmationVotePopup()}
 

--- a/packages/screens/Launchpad/MintCollectionScreen.tsx
+++ b/packages/screens/Launchpad/MintCollectionScreen.tsx
@@ -27,7 +27,7 @@ import { OptimizedImage } from "../../components/OptimizedImage";
 import { SVG } from "../../components/SVG";
 import { ScreenContainer } from "../../components/ScreenContainer";
 import { TertiaryBadge } from "../../components/badges/TertiaryBadge";
-import { TertiaryBox } from "../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../components/boxes/LegacyTertiaryBox";
 import { PrimaryButton } from "../../components/buttons/PrimaryButton";
 import { SecondaryButton } from "../../components/buttons/SecondaryButton";
 import { ProgressionCard } from "../../components/cards/ProgressionCard";
@@ -398,7 +398,7 @@ export const MintCollectionScreen: ScreenFC<"MintCollection"> = ({
                 }}
               />
 
-              <TertiaryBox noBrokenCorners fullWidth>
+              <LegacyTertiaryBox noBrokenCorners fullWidth>
                 {/* Upper section */}
                 <FlexRow
                   style={{
@@ -592,7 +592,7 @@ export const MintCollectionScreen: ScreenFC<"MintCollection"> = ({
                     )}
                   </View>
                 </FlexRow>
-              </TertiaryBox>
+              </LegacyTertiaryBox>
 
               {mintTermsConditionsURL && (
                 <View
@@ -663,7 +663,7 @@ export const MintCollectionScreen: ScreenFC<"MintCollection"> = ({
                 margin: layout.spacing_x2,
               }}
             >
-              <TertiaryBox style={{ marginBottom: 40 }}>
+              <LegacyTertiaryBox style={{ marginBottom: 40 }}>
                 {info.image ? (
                   <OptimizedImage
                     sourceURI={info.image}
@@ -687,7 +687,7 @@ export const MintCollectionScreen: ScreenFC<"MintCollection"> = ({
                     <ActivityIndicator size="large" style={{ margin: 40 }} />
                   </View>
                 )}
-              </TertiaryBox>
+              </LegacyTertiaryBox>
 
               <BrandText style={[fontSemibold20, { marginBottom: 24 }]}>
                 Activity
@@ -731,7 +731,7 @@ const AttributesCard: React.FC<{
   value: string;
 }> = ({ style, label, value }) => {
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       style={style}
       width={132}
       height={62}
@@ -747,7 +747,7 @@ const AttributesCard: React.FC<{
         {label}
       </BrandText>
       <BrandText style={fontMedium14}>{value}</BrandText>
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };
 

--- a/packages/screens/Launchpad/components/LaunchpadButton.tsx
+++ b/packages/screens/Launchpad/components/LaunchpadButton.tsx
@@ -4,7 +4,7 @@ import { Linking, Pressable, StyleSheet, View } from "react-native";
 import ChevronRightSvg from "../../../../assets/icons/chevron-right.svg";
 import { BrandText } from "../../../components/BrandText";
 import { SVG } from "../../../components/SVG";
-import { TertiaryBox } from "../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../components/boxes/LegacyTertiaryBox";
 import { SpacerColumn, SpacerRow } from "../../../components/spacer";
 import {
   neutral22,
@@ -33,7 +33,7 @@ export const LaunchpadButton: React.FC<LaunchpadButtonProps> = ({
       onPress={url ? () => Linking.openURL(url) : undefined}
       style={styles.fill}
     >
-      <TertiaryBox
+      <LegacyTertiaryBox
         style={styles.fill}
         fullWidth
         mainContainerStyle={styles.container}
@@ -50,7 +50,7 @@ export const LaunchpadButton: React.FC<LaunchpadButtonProps> = ({
             <SVG source={ChevronRightSvg} />
           </View>
         </View>
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </Pressable>
   );
 };

--- a/packages/screens/Message/components/ChatHeader.tsx
+++ b/packages/screens/Message/components/ChatHeader.tsx
@@ -11,7 +11,7 @@ import searchSVG from "../../../../assets/icons/search.svg";
 import { BrandText } from "../../../components/BrandText";
 import FlexRow from "../../../components/FlexRow";
 import { SVG } from "../../../components/SVG";
-import { TertiaryBox } from "../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../components/boxes/LegacyTertiaryBox";
 import { BackButton } from "../../../components/navigation/components/BackButton";
 import { SpacerRow } from "../../../components/spacer";
 import { useDropdowns } from "../../../context/DropdownsProvider";
@@ -201,7 +201,7 @@ export const ChatHeader = ({
                   <SVG source={dots} />
                 </TouchableOpacity>
                 {isDropdownOpen(dropdownRef) && (
-                  <TertiaryBox
+                  <LegacyTertiaryBox
                     width={140}
                     style={{ position: "absolute", top: 30, right: 10 }}
                     mainContainerStyle={{
@@ -240,7 +240,7 @@ export const ChatHeader = ({
                         </TouchableOpacity>
                       );
                     })}
-                  </TertiaryBox>
+                  </LegacyTertiaryBox>
                 )}
 
                 <SpacerRow size={1} />

--- a/packages/screens/Message/components/ConversationSelector.tsx
+++ b/packages/screens/Message/components/ConversationSelector.tsx
@@ -5,7 +5,7 @@ import chevronDownSVG from "../../../../assets/icons/chevron-down.svg";
 import chevronUpSVG from "../../../../assets/icons/chevron-up.svg";
 import { BrandText } from "../../../components/BrandText";
 import { SVG } from "../../../components/SVG";
-import { TertiaryBox } from "../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../components/boxes/LegacyTertiaryBox";
 import { SpacerRow } from "../../../components/spacer";
 import { useDropdowns } from "../../../context/DropdownsProvider";
 import { useMessage } from "../../../context/MessageProvider";
@@ -59,7 +59,7 @@ export const ConversationSelector: React.FC<{
       </TouchableOpacity>
 
       {isDropdownOpen(dropdownRef) && (
-        <TertiaryBox
+        <LegacyTertiaryBox
           width={172}
           style={{ position: "absolute", top: 30 }}
           mainContainerStyle={{
@@ -92,7 +92,7 @@ export const ConversationSelector: React.FC<{
               </TouchableOpacity>
             );
           })}
-        </TertiaryBox>
+        </LegacyTertiaryBox>
       )}
     </View>
   );

--- a/packages/screens/Message/components/GroupInvitationAction.tsx
+++ b/packages/screens/Message/components/GroupInvitationAction.tsx
@@ -12,7 +12,7 @@ import {
   selectConversationList,
 } from "../../../store/slices/message";
 import { RootState } from "../../../store/store";
-import { purpleDark, successColor } from "../../../utils/style/colors";
+import { successColor } from "../../../utils/style/colors";
 import { fontMedium10 } from "../../../utils/style/fonts";
 import { layout } from "../../../utils/style/layout";
 import { CONVERSATION_TYPES, Message } from "../../../utils/types/message";
@@ -111,12 +111,7 @@ export const GroupInvitationAction = ({
     <>
       <SpacerColumn size={1} />
       <FlexRow>
-        <PrimaryButton
-          text="Accept"
-          size="SM"
-          squaresBackgroundColor={purpleDark}
-          onPress={handleAcceptGroup}
-        />
+        <PrimaryButton text="Accept" size="SM" onPress={handleAcceptGroup} />
         <SpacerRow size={1} />
       </FlexRow>
     </>

--- a/packages/screens/Multisig/components/MultisigRightSection.tsx
+++ b/packages/screens/Multisig/components/MultisigRightSection.tsx
@@ -378,7 +378,7 @@ const JoinMultisigModal: React.FC<{
       visible={visible}
       onClose={onClose}
       label="Join multisig"
-      contentStyle={{ minWidth: 400 }}
+      boxStyle={{ minWidth: 400 }}
     >
       <TextInputCustom
         value={name}

--- a/packages/screens/RiotGame/RiotGameEnrollScreen.tsx
+++ b/packages/screens/RiotGame/RiotGameEnrollScreen.tsx
@@ -15,7 +15,7 @@ import closeSVG from "../../../assets/icons/close.svg";
 import { NFT } from "../../api/marketplace/v1/marketplace";
 import { BrandText } from "../../components/BrandText";
 import { SVG } from "../../components/SVG";
-import { TertiaryBox } from "../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../components/boxes/LegacyTertiaryBox";
 import { TertiaryButton } from "../../components/buttons/TertiaryButton";
 import { useFeedbacks } from "../../context/FeedbacksProvider";
 import { useRippers } from "../../hooks/riotGame/useRippers";
@@ -382,7 +382,7 @@ export const RiotGameEnrollScreen: React.FC = () => {
             </BrandText>
           </View>
 
-          <TertiaryBox
+          <LegacyTertiaryBox
             mainContainerStyle={{
               padding: layout.spacing_x4,
               alignItems: "flex-start",
@@ -396,7 +396,7 @@ export const RiotGameEnrollScreen: React.FC = () => {
                 .utc(stakingDuration)
                 .format("HH [hours] mm [minutes] ss [seconds]")}
             </BrandText>
-          </TertiaryBox>
+          </LegacyTertiaryBox>
 
           <View
             style={{

--- a/packages/screens/RiotGame/RiotGameInventoryScreen.tsx
+++ b/packages/screens/RiotGame/RiotGameInventoryScreen.tsx
@@ -8,7 +8,7 @@ import defaultInventoryItemPNG from "../../../assets/game/default-inventory-item
 import addCircleFilledSVG from "../../../assets/icons/add-circle-filled.svg";
 import { BrandText } from "../../components/BrandText";
 import FlexRow from "../../components/FlexRow";
-import { TertiaryBox } from "../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../components/boxes/LegacyTertiaryBox";
 import { CustomPressable } from "../../components/buttons/CustomPressable";
 import { PrimaryButtonOutline } from "../../components/buttons/PrimaryButtonOutline";
 import { useRippers } from "../../hooks/riotGame/useRippers";
@@ -64,7 +64,7 @@ export const RiotGameInventoryScreen = () => {
             keyExtractor={(item, index) => "" + index}
             renderItem={() => {
               return (
-                <TertiaryBox
+                <LegacyTertiaryBox
                   style={{ margin: layout.spacing_x1 }}
                   width={150}
                   height={150}
@@ -73,7 +73,7 @@ export const RiotGameInventoryScreen = () => {
                     style={{ width: 60, height: 90 }}
                     source={defaultInventoryItemPNG}
                   />
-                </TertiaryBox>
+                </LegacyTertiaryBox>
               );
             }}
           />
@@ -106,7 +106,7 @@ export const RiotGameInventoryScreen = () => {
             keyExtractor={(ripper) => ripper.id}
             renderItem={({ item: ripper }) => {
               return (
-                <TertiaryBox
+                <LegacyTertiaryBox
                   style={{ margin: layout.spacing_x1 }}
                   width={150}
                   height={150}
@@ -116,7 +116,7 @@ export const RiotGameInventoryScreen = () => {
                     source={ripper.imageUri}
                     isStaked={isNFTStaked(ripper)}
                   />
-                </TertiaryBox>
+                </LegacyTertiaryBox>
               );
             }}
           />

--- a/packages/screens/RiotGame/RiotGameLeaderboardScreen.tsx
+++ b/packages/screens/RiotGame/RiotGameLeaderboardScreen.tsx
@@ -23,7 +23,7 @@ import {
 import { BrandText } from "../../components/BrandText";
 import FlexRow from "../../components/FlexRow";
 import { SVG } from "../../components/SVG";
-import { TertiaryBox } from "../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../components/boxes/LegacyTertiaryBox";
 import { UserAvatarWithFrame } from "../../components/images/AvatarWithFrame";
 import { SpacerColumn, SpacerRow } from "../../components/spacer";
 import { useIsMobile } from "../../hooks/useIsMobile";
@@ -162,7 +162,7 @@ export const RiotGameLeaderboardScreen = () => {
         <BrandText style={fontMedium16}>{currentSeason?.id}</BrandText>
       </ImageBackground>
 
-      <TertiaryBox fullWidth style={{ marginTop: layout.spacing_x2 }}>
+      <LegacyTertiaryBox fullWidth style={{ marginTop: layout.spacing_x2 }}>
         <FlexRow>
           <View style={{ flex: 1 }}>
             <BrandText
@@ -192,7 +192,7 @@ export const RiotGameLeaderboardScreen = () => {
             </View>
           )}
         </FlexRow>
-      </TertiaryBox>
+      </LegacyTertiaryBox>
 
       <FlatList
         data={userScores}

--- a/packages/screens/RiotGame/RiotGameMemoriesScreen.tsx
+++ b/packages/screens/RiotGame/RiotGameMemoriesScreen.tsx
@@ -13,7 +13,7 @@ import { GameContentView } from "./component/GameContentView";
 import defaultSendToFightPNG from "../../../assets/game/default-video-send-to-fight.png";
 import { BrandText } from "../../components/BrandText";
 import { EmbeddedWeb } from "../../components/EmbeddedWeb";
-import { TertiaryBox } from "../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../components/boxes/LegacyTertiaryBox";
 import { SpacerColumn } from "../../components/spacer";
 import { useIsMobile } from "../../hooks/useIsMobile";
 import { fontMedium32 } from "../../utils/style/fonts";
@@ -81,7 +81,7 @@ export const RiotGameMemoriesScreen = () => {
         <BrandText style={[fontMedium32, titleStyles]}>
           The R!ot Season I
         </BrandText>
-        <TertiaryBox height={seasonVideoHeight} width={seasonVideoWidth}>
+        <LegacyTertiaryBox height={seasonVideoHeight} width={seasonVideoWidth}>
           {displayYT && (
             <EmbeddedWeb
               uri={seasonVideoUri}
@@ -89,7 +89,7 @@ export const RiotGameMemoriesScreen = () => {
               height={seasonVideoHeight - 2}
             />
           )}
-        </TertiaryBox>
+        </LegacyTertiaryBox>
 
         <SpacerColumn size={8} />
 
@@ -102,7 +102,7 @@ export const RiotGameMemoriesScreen = () => {
           numColumns={numCol}
           key={numCol}
           renderItem={({ item, index }) => (
-            <TertiaryBox
+            <LegacyTertiaryBox
               key={index}
               height={episodeVideoSmHeight - 2}
               width={episodeVideoSmWidth}
@@ -135,7 +135,7 @@ export const RiotGameMemoriesScreen = () => {
                   source={defaultSendToFightPNG}
                 />
               )}
-            </TertiaryBox>
+            </LegacyTertiaryBox>
           )}
         />
       </View>

--- a/packages/screens/RiotGame/component/AvailableRippersGrid.tsx
+++ b/packages/screens/RiotGame/component/AvailableRippersGrid.tsx
@@ -3,7 +3,7 @@ import { FlatList, TouchableOpacity } from "react-native";
 
 import { RipperAvatar } from "./RipperAvatar";
 import { NFT } from "../../../api/marketplace/v1/marketplace";
-import { TertiaryBox } from "../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../components/boxes/LegacyTertiaryBox";
 import { getRipperRarity, isNFTStaked } from "../../../utils/game";
 import { secondaryColor } from "../../../utils/style/colors";
 import { layout } from "../../../utils/style/layout";
@@ -40,7 +40,7 @@ export const AvailableRippersGrid: React.FC<AvailableRippersGridProps> = ({
             activeOpacity={0.6}
             onPress={() => selectRipper && selectRipper(ripper)}
           >
-            <TertiaryBox
+            <LegacyTertiaryBox
               style={{ margin: layout.spacing_x1 }}
               width={THUMB_CONTAINER_WIDTH}
               height={THUMB_CONTAINER_HEIGHT}
@@ -57,7 +57,7 @@ export const AvailableRippersGrid: React.FC<AvailableRippersGridProps> = ({
                 rarity={getRipperRarity(ripper)}
                 isStaked={isNFTStaked(ripper)}
               />
-            </TertiaryBox>
+            </LegacyTertiaryBox>
           </TouchableOpacity>
         );
       }}

--- a/packages/screens/RiotGame/component/BreedingResultModal.tsx
+++ b/packages/screens/RiotGame/component/BreedingResultModal.tsx
@@ -40,7 +40,7 @@ export const BreedingResultModal: React.FC<BreedingResultModalProps> = ({
   };
   return (
     <ModalBase
-      contentStyle={{ alignItems: "center" }}
+      boxStyle={{ alignItems: "center" }}
       labelComponent={
         <FlexRow>
           <BrandText style={fontSemibold20}>Success Breeding</BrandText>

--- a/packages/screens/RiotGame/component/BreedingSlot.tsx
+++ b/packages/screens/RiotGame/component/BreedingSlot.tsx
@@ -8,7 +8,7 @@ import { BrandText } from "../../../components/BrandText";
 import FlexRow from "../../../components/FlexRow";
 import { OptimizedImage } from "../../../components/OptimizedImage";
 import { SVG } from "../../../components/SVG";
-import { TertiaryBox } from "../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../components/boxes/LegacyTertiaryBox";
 import { useIsMobile } from "../../../hooks/useIsMobile";
 import { isNFTStaked } from "../../../utils/game";
 import {
@@ -40,7 +40,7 @@ export const BreedingSlot: React.FC<BreedingSlotProps> = ({
   const imageSize = computedSize - layout.spacing_x2 * 2;
   return (
     <TouchableOpacity activeOpacity={0.6} onPress={onPress}>
-      <TertiaryBox
+      <LegacyTertiaryBox
         width={computedSize}
         height={computedSize}
         mainContainerStyle={{
@@ -117,7 +117,7 @@ export const BreedingSlot: React.FC<BreedingSlotProps> = ({
             color={secondaryColor}
           />
         )}
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/screens/RiotGame/component/CollectionThumb.tsx
+++ b/packages/screens/RiotGame/component/CollectionThumb.tsx
@@ -3,7 +3,7 @@ import { TouchableOpacity } from "react-native";
 
 import { BrandText } from "../../../components/BrandText";
 import { OptimizedImage } from "../../../components/OptimizedImage";
-import { TertiaryBox } from "../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../components/boxes/LegacyTertiaryBox";
 import { useCollectionInfo } from "../../../hooks/useCollectionInfo";
 import { useAppNavigation } from "../../../utils/navigation";
 import { layout } from "../../../utils/style/layout";
@@ -24,7 +24,7 @@ export const CollectionThumb: React.FC<CollectionThumbProps> = ({
         navigation.navigate("RiotGameMarketplace", { collectionId })
       }
     >
-      <TertiaryBox
+      <LegacyTertiaryBox
         mainContainerStyle={{
           paddingTop: 12,
           paddingBottom: 20,
@@ -51,7 +51,7 @@ export const CollectionThumb: React.FC<CollectionThumbProps> = ({
         >
           {info?.name}
         </BrandText>
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/screens/RiotGame/component/EnrollSlot.tsx
+++ b/packages/screens/RiotGame/component/EnrollSlot.tsx
@@ -7,7 +7,7 @@ import { NFT } from "../../../api/marketplace/v1/marketplace";
 import { BrandText } from "../../../components/BrandText";
 import { OptimizedImage } from "../../../components/OptimizedImage";
 import { SVG } from "../../../components/SVG";
-import { TertiaryBox } from "../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../components/boxes/LegacyTertiaryBox";
 import { isNFTStaked } from "../../../utils/game";
 import {
   yellowDefault,
@@ -36,7 +36,7 @@ export const EnrollSlot: React.FC<EnrollSlotProps> = ({
 
   return (
     <TouchableOpacity activeOpacity={0.6} onPress={onPress}>
-      <TertiaryBox
+      <LegacyTertiaryBox
         width={172}
         height={148}
         mainContainerStyle={{
@@ -71,7 +71,7 @@ export const EnrollSlot: React.FC<EnrollSlotProps> = ({
         {isLeader && (
           <BrandText style={styles.leaderTitle}>Squad Leader</BrandText>
         )}
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/screens/RiotGame/component/InfoBox.tsx
+++ b/packages/screens/RiotGame/component/InfoBox.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { BrandText } from "../../../components/BrandText";
-import { TertiaryBox } from "../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../components/boxes/LegacyTertiaryBox";
 import { neutralA3 } from "../../../utils/style/colors";
 import {
   fontMedium10,
@@ -47,7 +47,7 @@ export const InfoBox: React.FC<InfoBoxProps> = ({
   }
 
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       width={width}
       height={height}
       style={{
@@ -62,6 +62,6 @@ export const InfoBox: React.FC<InfoBoxProps> = ({
     >
       <BrandText style={[titleFont, { color: neutralA3 }]}>{title}</BrandText>
       <BrandText style={[contentFont, { marginTop: 5 }]}>{content}</BrandText>
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };

--- a/packages/screens/RiotGame/component/RipperGridSelectorModal.tsx
+++ b/packages/screens/RiotGame/component/RipperGridSelectorModal.tsx
@@ -21,7 +21,7 @@ import { NFT } from "../../../api/marketplace/v1/marketplace";
 import { BrandText } from "../../../components/BrandText";
 import FlexRow from "../../../components/FlexRow";
 import { SVG } from "../../../components/SVG";
-import { TertiaryBox } from "../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../components/boxes/LegacyTertiaryBox";
 import { SpacerRow } from "../../../components/spacer";
 import { useIsMobile } from "../../../hooks/useIsMobile";
 import { getRipperRarity, isNFTStaked } from "../../../utils/game";
@@ -170,7 +170,7 @@ export const RipperSelectorModal: React.FC<RipperSelectorModalProps> = ({
                           activeOpacity={0.7}
                           onPress={() => selectRipper(item)}
                         >
-                          <TertiaryBox
+                          <LegacyTertiaryBox
                             noBrokenCorners
                             mainContainerStyle={[
                               {
@@ -215,7 +215,7 @@ export const RipperSelectorModal: React.FC<RipperSelectorModalProps> = ({
                                 }}
                               />
                             )}
-                          </TertiaryBox>
+                          </LegacyTertiaryBox>
                         </TouchableOpacity>
                       );
                     }}

--- a/packages/screens/RiotGame/component/UnstakeModal.tsx
+++ b/packages/screens/RiotGame/component/UnstakeModal.tsx
@@ -61,7 +61,7 @@ export const UnstakeModal: React.FC<UnstakeModalProps> = ({
 
   return (
     <ModalBase
-      contentStyle={{ alignItems: "center" }}
+      boxStyle={{ alignItems: "center" }}
       labelComponent={
         <FlexRow>
           <BrandText style={fontSemibold20}>Success Fight !</BrandText>

--- a/packages/screens/Swap/components/HowToBuy/HowToBuy.tsx
+++ b/packages/screens/Swap/components/HowToBuy/HowToBuy.tsx
@@ -10,7 +10,7 @@ import teritoriLogo from "../../../../../assets/icons/networks/teritori-circle.s
 import squidRouter from "../../../../../assets/icons/squidrouter.svg";
 import { BrandText } from "../../../../components/BrandText";
 import { SVG } from "../../../../components/SVG";
-import { TertiaryBox } from "../../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../../components/boxes/LegacyTertiaryBox";
 import { PrimaryButton } from "../../../../components/buttons/PrimaryButton";
 import { GradientText } from "../../../../components/gradientText";
 import { SeparatorGradient } from "../../../../components/separators/SeparatorGradient";
@@ -32,7 +32,7 @@ export const HowToBuy: React.FC = () => {
   const isHowToBuyExpanded = useSelector(selectIsHowToBuyExpanded);
 
   return (
-    <TertiaryBox fullWidth style={{ maxWidth: 600, alignSelf: "center" }}>
+    <LegacyTertiaryBox fullWidth style={{ maxWidth: 600, alignSelf: "center" }}>
       <View style={{ width: "100%" }}>
         <View
           style={{
@@ -96,7 +96,7 @@ export const HowToBuy: React.FC = () => {
           </View>
         </View>
       </View>
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };
 
@@ -320,7 +320,7 @@ const BuyingMethod: React.FC<{
       }}
       onPress={() => setSelectedMethod(method.name)}
     >
-      <TertiaryBox
+      <LegacyTertiaryBox
         mainContainerStyle={{
           borderColor:
             method.name === selectedMethod ? primaryColor : secondaryColor,
@@ -339,7 +339,7 @@ const BuyingMethod: React.FC<{
         </BrandText>
 
         {method.icon}
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </TouchableOpacity>
   );
 };

--- a/packages/screens/Swap/components/SwapView/SwapDetail.tsx
+++ b/packages/screens/Swap/components/SwapView/SwapDetail.tsx
@@ -5,7 +5,7 @@ import chevronDownSVG from "../../../../../assets/icons/chevron-down.svg";
 import chevronUpSVG from "../../../../../assets/icons/chevron-up.svg";
 import { BrandText } from "../../../../components/BrandText";
 import { SVG } from "../../../../components/SVG";
-import { TertiaryBox } from "../../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../../components/boxes/LegacyTertiaryBox";
 import { Separator } from "../../../../components/separators/Separator";
 import { SpacerColumn } from "../../../../components/spacer";
 import {
@@ -46,7 +46,7 @@ export const SwapDetail: React.FC<{
       onPress={() => setIsOpen((isOpen) => !isOpen && !!amountIn)}
       style={{ width: "100%" }}
     >
-      <TertiaryBox
+      <LegacyTertiaryBox
         fullWidth
         mainContainerStyle={{ padding: layout.spacing_x2 }}
       >
@@ -122,7 +122,7 @@ export const SwapDetail: React.FC<{
             </View>
           </>
         )}
-      </TertiaryBox>
+      </LegacyTertiaryBox>
     </Pressable>
   );
 };

--- a/packages/screens/Swap/components/SwapView/SwapSettings.tsx
+++ b/packages/screens/Swap/components/SwapView/SwapSettings.tsx
@@ -11,7 +11,7 @@ import { Pressable, View } from "react-native";
 import infoSVG from "../../../../../assets/icons/info.svg";
 import { BrandText } from "../../../../components/BrandText";
 import { SVG } from "../../../../components/SVG";
-import { TertiaryBox } from "../../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../../components/boxes/LegacyTertiaryBox";
 import { CustomPressable } from "../../../../components/buttons/CustomPressable";
 import { TextInputCustom } from "../../../../components/inputs/TextInputCustom";
 import {
@@ -130,7 +130,7 @@ export const SwapSettings: React.FC<{
   if (settingsOpened)
     return (
       <FadeInView style={{ position: "absolute", right: 20, top: 55 }}>
-        <TertiaryBox
+        <LegacyTertiaryBox
           mainContainerStyle={{
             padding: layout.spacing_x2_5,
             alignItems: "flex-start",
@@ -164,7 +164,7 @@ export const SwapSettings: React.FC<{
             </CustomPressable>
           </View>
 
-          <TertiaryBox
+          <LegacyTertiaryBox
             mainContainerStyle={{
               padding: layout.spacing_x0_5,
               flexDirection: "row",
@@ -230,11 +230,11 @@ export const SwapSettings: React.FC<{
                 %
               </BrandText>
             </SelectableItem>
-          </TertiaryBox>
+          </LegacyTertiaryBox>
 
           {/*====== Info box */}
           {infoVisible && (
-            <TertiaryBox
+            <LegacyTertiaryBox
               mainContainerStyle={{ padding: layout.spacing_x2 }}
               style={{ position: "absolute", left: -36, top: -26 }}
               noBrokenCorners
@@ -243,9 +243,9 @@ export const SwapSettings: React.FC<{
                 Your transaction will revert if the price changes {"\n"}
                 unfavorably by more than this percentage.
               </BrandText>
-            </TertiaryBox>
+            </LegacyTertiaryBox>
           )}
-        </TertiaryBox>
+        </LegacyTertiaryBox>
       </FadeInView>
     );
   return <></>;

--- a/packages/screens/Swap/components/SwapView/SwapTokensList.tsx
+++ b/packages/screens/Swap/components/SwapView/SwapTokensList.tsx
@@ -5,7 +5,7 @@ import { TouchableOpacity } from "react-native-gesture-handler";
 import { SelectableCurrency } from "./SelectableCurrency";
 import chevronUpSVG from "../../../../../assets/icons/chevron-up.svg";
 import { SVG } from "../../../../components/SVG";
-import { TertiaryBox } from "../../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../../components/boxes/LegacyTertiaryBox";
 import { CurrencyInfo } from "../../../../networks";
 import { layout } from "../../../../utils/style/layout";
 import { FadeInView } from "../FadeInView";
@@ -28,7 +28,7 @@ export const SwapTokensList: React.FC<{
     return (
       <View style={styles.modalContainer}>
         <FadeInView style={{ position: "absolute", left: 20, top: 50 }}>
-          <TertiaryBox
+          <LegacyTertiaryBox
             mainContainerStyle={{
               padding: layout.spacing_x2_5,
               alignItems: "flex-start",
@@ -69,7 +69,7 @@ export const SwapTokensList: React.FC<{
                 />
               ))}
             </View>
-          </TertiaryBox>
+          </LegacyTertiaryBox>
         </FadeInView>
       </View>
     );

--- a/packages/screens/Swap/components/SwapView/SwapView.tsx
+++ b/packages/screens/Swap/components/SwapView/SwapView.tsx
@@ -12,7 +12,7 @@ import chevronCircleDown from "../../../../../assets/icons/chevron-circle-down.s
 import chevronCircleUp from "../../../../../assets/icons/chevron-circle-up.svg";
 import { BrandText } from "../../../../components/BrandText";
 import { SVG } from "../../../../components/SVG";
-import { TertiaryBox } from "../../../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../../../components/boxes/LegacyTertiaryBox";
 import { CustomPressable } from "../../../../components/buttons/CustomPressable";
 import { PrimaryButton } from "../../../../components/buttons/PrimaryButton";
 import { SecondaryButton } from "../../../../components/buttons/SecondaryButton";
@@ -313,7 +313,10 @@ export const SwapView: React.FC = () => {
 
   // ===== RETURN
   return (
-    <TertiaryBox fullWidth style={{ maxWidth: MAX_WIDTH, alignSelf: "center" }}>
+    <LegacyTertiaryBox
+      fullWidth
+      style={{ maxWidth: MAX_WIDTH, alignSelf: "center" }}
+    >
       <View style={{ width: "100%" }} onLayout={onLayout}>
         <View
           style={{
@@ -339,7 +342,7 @@ export const SwapView: React.FC = () => {
           >
             <View style={{ width: "100%" }}>
               {/*======= First currency */}
-              <TertiaryBox
+              <LegacyTertiaryBox
                 fullWidth
                 mainContainerStyle={{
                   padding: layout.spacing_x2,
@@ -429,11 +432,11 @@ export const SwapView: React.FC = () => {
                     </View>
                   </View>
                 </Animated.View>
-              </TertiaryBox>
+              </LegacyTertiaryBox>
 
               {/*======= Second currency */}
               <SpacerColumn size={1.5} />
-              <TertiaryBox
+              <LegacyTertiaryBox
                 fullWidth
                 mainContainerStyle={{
                   padding: layout.spacing_x2,
@@ -489,7 +492,7 @@ export const SwapView: React.FC = () => {
                     </View>
                   </Animated.View>
                 </>
-              </TertiaryBox>
+              </LegacyTertiaryBox>
             </View>
 
             {/*======= Currencies In/Out equivalence */}
@@ -550,6 +553,6 @@ export const SwapView: React.FC = () => {
           setCurrency={setCurrencyIn}
         />
       </View>
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };

--- a/packages/screens/TeritoriNameService/TNSBurnNameScreen.tsx
+++ b/packages/screens/TeritoriNameService/TNSBurnNameScreen.tsx
@@ -94,9 +94,8 @@ export const TNSBurnNameScreen: React.FC<TNSBurnNameScreenProps> = ({
       hideMainSeparator
       onClose={() => onClose()}
       width={457}
-      contentStyle={{
+      boxStyle={{
         backgroundColor: neutral17,
-        borderRadius: 8,
       }}
     >
       <View

--- a/packages/screens/TeritoriNameService/TNSConsultNameScreen.tsx
+++ b/packages/screens/TeritoriNameService/TNSConsultNameScreen.tsx
@@ -63,7 +63,6 @@ const NotOwnerActions: React.FC<{
             onClose();
             navigation.navigate("UserPublicProfile", { id: ownerId });
           }}
-          squaresBackgroundColor={neutral17}
         />
       )}
       <PrimaryButton
@@ -72,7 +71,6 @@ const NotOwnerActions: React.FC<{
         text="Send funds"
         // TODO: if no signed, connectKeplr, then, open modal
         onPress={() => setSendFundsModalVisible(true)}
-        squaresBackgroundColor={neutral17}
       />
       <TNSSendFundsModal
         onClose={() => setSendFundsModalVisible(false)}
@@ -209,7 +207,7 @@ export const TNSConsultNameScreen: React.FC<TNSConsultNameProps> = ({
       hideMainSeparator
       label={name}
       width={457}
-      contentStyle={{
+      boxStyle={{
         backgroundColor: neutral17,
         borderWidth: 1,
         borderColor: neutral33,

--- a/packages/screens/TeritoriNameService/TNSExploreScreen.tsx
+++ b/packages/screens/TeritoriNameService/TNSExploreScreen.tsx
@@ -70,7 +70,6 @@ export const TNSExploreScreen: React.FC<TNSExploreScreenProps> = ({
               onPress={() => {
                 onClose("TNSConsultName");
               }}
-              squaresBackgroundColor={neutral17}
             />
             <PrimaryButtonOutline
               size="XL"

--- a/packages/screens/TeritoriNameService/TNSMintNameScreen.tsx
+++ b/packages/screens/TeritoriNameService/TNSMintNameScreen.tsx
@@ -272,7 +272,7 @@ export const TNSMintNameModal: React.FC<
       scrollable
       label={name}
       hideMainSeparator
-      contentStyle={{
+      boxStyle={{
         backgroundColor: neutral17,
       }}
     >

--- a/packages/screens/TeritoriNameService/TNSRegisterScreen.tsx
+++ b/packages/screens/TeritoriNameService/TNSRegisterScreen.tsx
@@ -8,7 +8,7 @@ import { useTNS } from "../../context/TNSProvider";
 import { useNSMintAvailability } from "../../hooks/useNSMintAvailability";
 import { useSelectedNetworkId } from "../../hooks/useSelectedNetwork";
 import { getCosmosNetwork } from "../../networks";
-import { neutral00, neutral17, neutral33 } from "../../utils/style/colors";
+import { neutral00, neutral33 } from "../../utils/style/colors";
 
 interface TNSRegisterScreenProps {
   onClose: TNSCloseHandler;
@@ -55,7 +55,6 @@ export const TNSRegisterScreen: React.FC<TNSRegisterScreenProps> = ({
           <PrimaryButton
             size="XL"
             width={280}
-            squaresBackgroundColor={neutral17}
             text="Register your Username"
             onPress={() => {
               setName(name);
@@ -72,7 +71,6 @@ export const TNSRegisterScreen: React.FC<TNSRegisterScreenProps> = ({
             onPress={() => {
               onClose("TNSConsultName");
             }}
-            squaresBackgroundColor={neutral17}
           />
         )}
       </FindAName>

--- a/packages/screens/TeritoriNameService/TNSUpdateNameScreen.tsx
+++ b/packages/screens/TeritoriNameService/TNSUpdateNameScreen.tsx
@@ -199,7 +199,7 @@ export const TNSUpdateNameScreen: React.FC<TNSUpdateNameScreenProps> = ({
       onClose={() => onClose()}
       scrollable
       width={457}
-      contentStyle={{
+      boxStyle={{
         backgroundColor: neutral17,
       }}
     >

--- a/packages/screens/WalletManager/WalletDashboardHeader.tsx
+++ b/packages/screens/WalletManager/WalletDashboardHeader.tsx
@@ -5,7 +5,7 @@ import { TouchableOpacity } from "react-native-gesture-handler";
 import penSVG from "../../../assets/icons/manage.svg";
 import { BrandText } from "../../components/BrandText";
 import { SVG } from "../../components/SVG";
-import { TertiaryBox } from "../../components/boxes/TertiaryBox";
+import { LegacyTertiaryBox } from "../../components/boxes/LegacyTertiaryBox";
 import { PrimaryButton } from "../../components/buttons/PrimaryButton";
 import { useBalances } from "../../hooks/useBalances";
 import { useDelegations } from "../../hooks/useDelegations";
@@ -34,7 +34,7 @@ const WalletDashboardHeaderCard: React.FC<WalletDashboardHeaderProps> = ({
   actionButton,
 }) => {
   return (
-    <TertiaryBox
+    <LegacyTertiaryBox
       height={116}
       width={200}
       mainContainerStyle={{
@@ -75,7 +75,6 @@ const WalletDashboardHeaderCard: React.FC<WalletDashboardHeaderProps> = ({
             size="XS"
             text={actionButton.label}
             onPress={actionButton.onPress}
-            squaresBackgroundColor={neutral17}
             touchableStyle={{
               position: "absolute",
               bottom: 12,
@@ -84,7 +83,7 @@ const WalletDashboardHeaderCard: React.FC<WalletDashboardHeaderProps> = ({
           />
         )}
       </View>
-    </TertiaryBox>
+    </LegacyTertiaryBox>
   );
 };
 

--- a/packages/utils/themes.ts
+++ b/packages/utils/themes.ts
@@ -1,11 +1,14 @@
 export interface Theme {
   textColor: string;
+  backgroundColor: string;
 }
 
 export const lightTheme: Theme = {
   textColor: "black",
+  backgroundColor: "white",
 };
 
 export const darkTheme: Theme = {
   textColor: "white",
+  backgroundColor: "black",
 };


### PR DESCRIPTION
refactor boxes to simplify them:

adds a base box component that support either gradients or notched (broken corners)
<img width="286" alt="Screenshot 2023-12-07 at 12 41 07" src="https://github.com/TERITORI/teritori-dapp/assets/7917064/6e827a2b-dde1-4f65-a546-9161e4aa1692">

and now specialized boxes only take style and children props
before:
<img width="379" alt="Screenshot 2023-12-07 at 12 39 41" src="https://github.com/TERITORI/teritori-dapp/assets/7917064/7c8559f3-36d2-4b30-bb9e-61c669b71075">
after:
<img width="274" alt="Screenshot 2023-12-07 at 12 39 54" src="https://github.com/TERITORI/teritori-dapp/assets/7917064/ace36aa7-9d94-4627-8f96-f2ad4b7d253b">

this also removes the "black squares" on notched (broken corners) boxes by using a rounded corner with filler views
<img width="397" alt="Screenshot 2023-12-07 at 12 38 46" src="https://github.com/TERITORI/teritori-dapp/assets/7917064/ced3f33b-9f37-4d84-b73a-23cda00e881b">
thanks @sakul-budhathoki 
