### PR TITLE
fix: add default image for Post Audio

### DIFF
--- a/packages/components/socialFeed/SocialCard/SocialMessageContent.tsx
+++ b/packages/components/socialFeed/SocialCard/SocialMessageContent.tsx
@@ -3,6 +3,7 @@ import { View } from "react-native";
 import { v4 as uuidv4 } from "uuid";
 
 import { ArticleRenderer } from "./ArticleRenderer";
+import defaultThumbnailImage from "../../../../assets/default-images/default-track-thumbnail.png";
 import { Post } from "../../../api/feed/v1/feed";
 import { HTML_TAG_REGEXP } from "../../../utils/regex";
 import { zodTryParseJSON } from "../../../utils/sanitize";
@@ -105,6 +106,7 @@ export const SocialMessageContent: React.FC<Props> = ({ post, isPreview }) => {
                 fileUrl={file.url}
                 waveform={file.audioMetadata?.waveform || []}
                 imageURI={file.thumbnailFileData?.url}
+                fallbackImageURI={defaultThumbnailImage}
               />
             </Fragment>
           ))}


### PR DESCRIPTION
Before
![image](https://github.com/TERITORI/teritori-dapp/assets/50441633/fd975bb4-ed8c-47d9-ba3e-a463fdbb0f65)

After
![image](https://github.com/TERITORI/teritori-dapp/assets/50441633/574581fa-a715-4845-8900-289c07adac94)
