### PR TITLE
fix: prevent feed input from disappearing when resizing the window

### DIFF
--- a/packages/components/socialFeed/NewsFeed/NewsFeed.tsx
+++ b/packages/components/socialFeed/NewsFeed/NewsFeed.tsx
@@ -112,12 +112,6 @@ export const NewsFeed: React.FC<NewsFeedProps> = ({
   const ListHeaderComponent = useCallback(
     () => (
       <>
-        <View
-          onLayout={onHeaderLayout}
-          style={{ width, alignSelf: "center", alignItems: "center" }}
-        >
-          <Header />
-        </View>
         {!disablePosting && (
           <Animated.View
             style={[
@@ -155,7 +149,6 @@ export const NewsFeed: React.FC<NewsFeedProps> = ({
       </>
     ),
     [
-      Header,
       additionalHashtag,
       additionalMention,
       daoId,
@@ -163,7 +156,6 @@ export const NewsFeed: React.FC<NewsFeedProps> = ({
       isLoadingValue,
       isMobile,
       refetch,
-      width,
     ],
   );
 
@@ -227,7 +219,17 @@ export const NewsFeed: React.FC<NewsFeedProps> = ({
           width: windowWidth,
           maxWidth: screenContentMaxWidth,
         }}
-        ListHeaderComponent={ListHeaderComponent}
+        ListHeaderComponent={
+          <>
+            <View
+              onLayout={onHeaderLayout}
+              style={{ width, alignSelf: "center", alignItems: "center" }}
+            >
+              <Header />
+            </View>
+            <ListHeaderComponent />
+          </>
+        }
         keyExtractor={(post: Post) => post.identifier}
         onScroll={scrollHandler}
         contentContainerStyle={contentCStyle}


### PR DESCRIPTION
To test : 
- Go here : https://app.teritori.com/feed
- Write something in the input 
![image](https://github.com/TERITORI/teritori-dapp/assets/50441633/d120018d-9a16-4a3a-be64-e7b9b2354af4)
- Resize the browser window and see the written text disappears
---

### ==> Fixed