### PR TITLE
feat(MarketplaceScreen): Update volume labels

### DIFF
--- a/go/pkg/marketplace/marketplace_service.go
+++ b/go/pkg/marketplace/marketplace_service.go
@@ -219,9 +219,9 @@ func (s *MarkteplaceService) Collections(req *marketplacepb.CollectionsRequest, 
 			OFFSET ?
 		`, where, orderSQL), // order By here or it won't work
 			s.conf.Whitelist,
-			time.Now().AddDate(0, 0, -30),
-			time.Now().AddDate(0, 0, -30),
-			time.Now().AddDate(0, 0, -60),
+			time.Now().AddDate(0, 0, -1),
+			time.Now().AddDate(0, 0, -1),
+			time.Now().AddDate(0, 0, -2),
 			limit,
 			offset,
 		).Scan(&collections).Error

--- a/packages/screens/Marketplace/MarketplaceScreen.tsx
+++ b/packages/screens/Marketplace/MarketplaceScreen.tsx
@@ -54,11 +54,11 @@ const TABLE_ROWS = {
     flex: 3,
   },
   TimePeriodVolume: {
-    label: "30d Volume",
+    label: "24h Volume",
     flex: 3,
   },
   TimePeriodPercentualVolume: {
-    label: "30d % Volume",
+    label: "24h % Volume",
     flex: 3,
   },
   sales: {


### PR DESCRIPTION
- Update label "30d Volume" to "24h Volume" in MarketplaceScreen.tsx
- Update label "30d % Volume" to "24h % Volume" in MarketplaceScreen.tsx

fix(marketplace_service): Adjust date range

- Adjust date range in marketplace_service.go to fetch data for the last 24 hours instead of the last 30 days