### PR TITLE
chore: easier local js lint

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -23,23 +23,8 @@ jobs:
       - name: Lint
         run: make lint.js
 
-      - name: Validate networks
-        run: make validate-networks
-
-      - name: Validate expo config
-        run: npx expo-doctor
-
-      - name: Check for unused environment variables
-        run: npx ts-node packages/scripts/unusedEnv.ts
-
-      - name: Check dependencies
-        run: npx depcheck
-
       - name: Build web app
         run: yarn expo export:web
 
       - name: Check that there is no diff
         run: git diff --exit-code
-
-      - name: Check typescript unused exports
-        run: make unused-exports

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ publish.multisig-backend:
 
 .PHONY: validate-networks
 validate-networks: node_modules
-	npx ts-node packages/scripts/validateNetworks.ts
+	yarn validate-networks
 
 .PHONY: networks.json
 networks.json: node_modules validate-networks
@@ -277,7 +277,7 @@ networks.json: node_modules validate-networks
 .PHONY: unused-exports
 unused-exports: node_modules
 	## TODO unexclude all paths except packages/api;packages/contracts-clients;packages/evm-contracts-clients
-	npx ts-unused-exports ./tsconfig.json --excludePathsFromReport="packages/api;packages/contracts-clients;packages/evm-contracts-clients;packages/components/socialFeed/RichText/inline-toolbar;./App.tsx;.*\.web|.electron|.d.ts" --ignoreTestFiles 
+	yarn unused-exports
 
 .PHONY: prepare-electron
 prepare-electron: node_modules

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "web": "expo start --web",
     "eject": "expo eject",
     "build:web": "expo export:web",
-    "lint": "eslint --cache --ext .js,.jsx,.ts,.tsx . && tsc",
+    "lint": "eslint --cache --ext .js,.jsx,.ts,.tsx . && tsc && depcheck && yarn unused-exports && yarn validate-networks && expo-doctor && ts-node packages/scripts/unusedEnv.ts",
     "lint-fix": "eslint --cache --ext .js,.jsx,.ts,.tsx . --fix",
+    "unused-exports": "ts-unused-exports ./tsconfig.json --excludePathsFromReport=\"packages/api;packages/contracts-clients;packages/evm-contracts-clients;packages/components/socialFeed/RichText/inline-toolbar;./App.tsx;.*\\.web|.electron|.d.ts\" --ignoreTestFiles",
+    "validate-networks": "ts-node packages/scripts/validateNetworks.ts",
     "postinstall": "patch-package"
   },
   "engines": {


### PR DESCRIPTION
with this we can run most of the js checks locally in a single command with `make lint.js` (aka `yarn && yarn lint`)
only non-destructive checks are ran