### PR TITLE
fix: don't crop text in mini mode inputs

### DIFF
--- a/packages/screens/Mini/Chat/MiniFriendScreen.tsx
+++ b/packages/screens/Mini/Chat/MiniFriendScreen.tsx
@@ -74,7 +74,7 @@ export const MiniFriendScreen: ScreenFC<"MiniFriend"> = ({ navigation }) => {
           icon={searchSVG}
           placeholder="Search Friend Requests"
           style={{ paddingVertical: layout.spacing_x1 }}
-          inputStyle={[fontMedium14]}
+          inputStyle={[fontMedium14, { lineHeight: 0 }]}
         />
         <SpacerColumn size={2} />
 

--- a/packages/screens/Mini/Chat/NewConversationScreen.tsx
+++ b/packages/screens/Mini/Chat/NewConversationScreen.tsx
@@ -69,7 +69,7 @@ export const NewConversationScreen: ScreenFC<"MiniNewConversation"> = ({
           icon={searchSVG}
           placeholder="Search by nickname"
           style={{ paddingVertical: layout.spacing_x1 }}
-          inputStyle={[fontMedium14]}
+          inputStyle={[fontMedium14, { lineHeight: 0 }]}
         />
         <SpacerColumn size={2} />
         <NewConversationOrGroupSelector

--- a/packages/screens/Mini/Chat/NewGroupScreen.tsx
+++ b/packages/screens/Mini/Chat/NewGroupScreen.tsx
@@ -137,7 +137,7 @@ export const NewGroupScreen: ScreenFC<"MiniNewGroup"> = ({ navigation }) => {
           icon={searchSVG}
           placeholder="Search by nickname"
           style={{ paddingVertical: layout.spacing_x1 }}
-          inputStyle={[fontMedium14]}
+          inputStyle={[fontMedium14, { lineHeight: 0 }]}
           placeholderTextColor={neutralA3}
         />
         <SpacerColumn size={2} />

--- a/packages/screens/Mini/Conversation/ChatInput.tsx
+++ b/packages/screens/Mini/Conversation/ChatInput.tsx
@@ -158,7 +158,7 @@ export const ChatInput = ({ conversationId, replyTo, clearReplyTo }: Props) => {
             value={newMessage}
             onChangeText={onNewMessageChange}
             style={{ paddingVertical: layout.spacing_x1 }}
-            inputStyle={[fontMedium16, { color: neutral77 }]}
+            inputStyle={[fontMedium16, { color: neutral77, lineHeight: 0 }]}
             numberOfLines={6}
             multiline
             autoFocus


### PR DESCRIPTION
Before:
<img width="334" alt="Screenshot 2024-02-12 at 1 48 24 PM" src="https://github.com/TERITORI/teritori-dapp/assets/155436948/44a6a694-0803-49dc-836c-37153d05f077">

After:
![Screenshot 2024-02-12 at 1 41 40 PM](https://github.com/TERITORI/teritori-dapp/assets/155436948/a6759166-64e5-4ef6-a3b3-ea6645eaf5c9)
