### PR TITLE
feat: android eas submit

### DIFF
--- a/.github/workflows/mobile-build-android.yml
+++ b/.github/workflows/mobile-build-android.yml
@@ -37,12 +37,11 @@ jobs:
         run: yarn install
 
       - name: Bump android versionNumber
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: make bump-app-build-number
 
       - name: Download service account from env
-        env:
-          DATA: ${{ secrets.GOOGLE_SERVICES_JSON }}
-        run: echo $DATA > ./service-account-android-submit.json
+        run: echo ${{ secrets.GOOGLE_SERVICES_JSON }} | base64 --decode > ./service-account-android-submit.json
 
       - name: Fix gitignore
         run: npx tsx ./packages/scripts/app-build/fixGitignore.ts
@@ -73,7 +72,6 @@ jobs:
             exit 1
           fi
 
-          # eas submit --platform=android --path=$AAB_FILE --profile=production
           echo "AAB_FILE=$AAB_FILE" >> $GITHUB_ENV
 
       - name: EAS Submit Android aab

--- a/.github/workflows/mobile-build-android.yml
+++ b/.github/workflows/mobile-build-android.yml
@@ -36,6 +36,14 @@ jobs:
       - name: Install node modules
         run: yarn install
 
+      - name: Bump android versionNumber
+        run: make bump-app-build-number
+
+      - name: Download service account from env
+        env:
+          DATA: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: echo $DATA > ./service-account-android-submit.json
+
       - name: Fix gitignore
         run: npx tsx ./packages/scripts/app-build/fixGitignore.ts
 
@@ -57,7 +65,7 @@ jobs:
       - name: Build android
         run: eas build --local --non-interactive --platform=android
 
-      - name: EAS Submit aab
+      - name: Update aab File path
         run: |
           AAB_FILE=$(find ./ -name 'build-*.aab' -type f)
           if [ -z "$AAB_FILE" ]; then
@@ -67,6 +75,9 @@ jobs:
 
           # eas submit --platform=android --path=$AAB_FILE --profile=production
           echo "AAB_FILE=$AAB_FILE" >> $GITHUB_ENV
+
+      - name: EAS Submit Android aab
+        run: eas submit --platform=android --path=${{ env.AAB_FILE }} --profile=production
 
       - name: Upload aab
         uses: actions/upload-artifact@v3

--- a/.github/workflows/mobile-build-android.yml
+++ b/.github/workflows/mobile-build-android.yml
@@ -41,6 +41,7 @@ jobs:
         run: make bump-app-build-number
 
       - name: Download service account from env
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: echo ${{ secrets.GOOGLE_SERVICES_JSON }} | base64 --decode > ./service-account-android-submit.json
 
       - name: Fix gitignore
@@ -75,6 +76,7 @@ jobs:
           echo "AAB_FILE=$AAB_FILE" >> $GITHUB_ENV
 
       - name: EAS Submit Android aab
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: eas submit --platform=android --path=${{ env.AAB_FILE }} --profile=production
 
       - name: Upload aab

--- a/.github/workflows/mobile-build-ios.yml
+++ b/.github/workflows/mobile-build-ios.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Bump ios buildNumber
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        run: make bump-ios-build-number
+        run: make bump-app-build-number
 
       - name: Fix gitignore
         run: npx tsx ./packages/scripts/app-build/fixGitignore.ts

--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ init-weshd-go:
 	cd ./weshd && go install golang.org/x/mobile/cmd/gomobile
 	cd ./weshd && gomobile init
 
-.PHONY: bump-ios-build-number
-bump-ios-build-number:  
+.PHONY: bump-app-build-number
+bump-app-build-number:  
 	npx tsx packages/scripts/app-build/bumpBuildNumber.ts $(shell echo $$(($$(git rev-list HEAD --count) + 10)))
 

--- a/app.config.js
+++ b/app.config.js
@@ -35,6 +35,7 @@ const config = {
         backgroundColor: "#FFFFFF",
       },
       package: "com.teritori",
+      versionCode: "5",
     },
     web: {
       bundler: "metro",

--- a/app.config.js
+++ b/app.config.js
@@ -35,7 +35,7 @@ const config = {
         backgroundColor: "#FFFFFF",
       },
       package: "com.teritori",
-      versionCode: "5",
+      versionCode: "6",
     },
     web: {
       bundler: "metro",

--- a/eas.json
+++ b/eas.json
@@ -21,7 +21,8 @@
   "submit": {
     "production": {
       "android": {
-        "track": "internal"
+        "track": "internal",
+        "serviceAccountKeyPath": "./service-account-android-submit.json"
       },
       "ios": {
         "appleId": "sakulbudhathoki977@gmail.com",

--- a/eas.json
+++ b/eas.json
@@ -22,7 +22,8 @@
     "production": {
       "android": {
         "track": "internal",
-        "serviceAccountKeyPath": "./service-account-android-submit.json"
+        "serviceAccountKeyPath": "./service-account-android-submit.json",
+        "releaseStatus": "draft"
       },
       "ios": {
         "appleId": "sakulbudhathoki977@gmail.com",

--- a/packages/scripts/app-build/bumpBuildNumber.ts
+++ b/packages/scripts/app-build/bumpBuildNumber.ts
@@ -1,16 +1,19 @@
 import fs from "fs";
 
 const FILE_PATH = "./app.config.js";
-const buildNumber = process.argv[2];
+const incrementalNumber = process.argv[2];
 
 fs.readFile(FILE_PATH, "utf8", (err, data) => {
   if (err) {
     console.error("Error reading app.config.js", err);
     process.exit(1);
   }
-  const regex = /buildNumber: "(\d+)"/;
+  const regexBuildNumber = /buildNumber: "(\d+)"/;
+  const regexVersionCode = /versionCode: "(\d+)"/;
 
-  const updatedData = data.replace(regex, 'buildNumber: "' + buildNumber + '"');
+  const updatedData = data
+    .replace(regexBuildNumber, 'buildNumber: "' + incrementalNumber + '"')
+    .replace(regexVersionCode, 'versionCode: "' + incrementalNumber + '"');
 
   fs.writeFile(FILE_PATH, updatedData, "utf8", (err) => {
     if (err) {


### PR DESCRIPTION
Done:
- config between Google Play Console, Google Cloud, and Expo has been done
- env set for Google service account
- eas submit is submitting to the expo.dev
- expo.dev uploads to Google Play Console

The app is submitted to the Play Store for internal testing as a draft app
So, it will not be released for testing; has to be manually released from Google Play Console.
`[!] Google Api Error: Invalid request - Only releases with status draft may be created on the draft app.`

It will be automatically released for internal testing once we make the app production; for that, we should release the app to general users once. 

On latest commit: It is configured the submit only after merging to main
To check the eas submit: https://github.com/TERITORI/teritori-dapp/actions/runs/7886701324/job/21520435858?pr=950
 