### PR TITLE
chore(deps): update typescript to version 5.3.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "rimraf": "^5.0.5",
     "ts-proto": "^1.120.0",
     "ts-unused-exports": "^10.0.1",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.0"
   },
   "resolutions": {
     "@gnolang/tm2-js-client@^1.0.0": "patch:@gnolang/tm2-js-client@npm%3A1.0.1#./.yarn/patches/@gnolang-tm2-js-client-npm-1.0.1-9e54bafbb3.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19137,7 +19137,7 @@ __metadata:
     ts-proto: ^1.120.0
     ts-unused-exports: ^10.0.1
     tsx: ^4.7.0
-    typescript: ^5.2.2
+    typescript: ^5.3.0
     uuid: ^9.0.0
     victory: ^36.6.12
     victory-native: ^36.6.8
@@ -19589,7 +19589,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.2.2":
+"typescript@npm:^5.3.0":
   version: 5.3.3
   resolution: "typescript@npm:5.3.3"
   bin:
@@ -19609,7 +19609,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
+"typescript@patch:typescript@^5.3.0#~builtin<compat/typescript>":
   version: 5.3.3
   resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=85af82"
   bin:


### PR DESCRIPTION
The expo version currently used ask for a minimum of 5.3.0