### PR TITLE
fix: title not showing and extra bottom margin on dApp store screen for android 

### DIFF
--- a/packages/screens/Mini/DAppStore/DAppStoreScreen.tsx
+++ b/packages/screens/Mini/DAppStore/DAppStoreScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { FlatList, useWindowDimensions, View } from "react-native";
+import { FlatList, Platform, useWindowDimensions, View } from "react-native";
 
 import { DAppStoreMenuItem } from "./component/DAppStoreMenuItems";
 import { DAppsList } from "./component/DAppsList";
@@ -20,7 +20,7 @@ import { layout } from "@/utils/style/layout";
 
 export const DAppStoreScreen: ScreenFC<"MiniDAppStore"> = ({ navigation }) => {
   const [enableEditingDApps, setEnableEditingDApps] = useState(false);
-  const { height: windowHeight } = useWindowDimensions();
+  const { height: windowHeight, width: windowWidth } = useWindowDimensions();
   const toggleEnableEditingDApps = () => setEnableEditingDApps((prev) => !prev);
 
   return (
@@ -32,8 +32,10 @@ export const DAppStoreScreen: ScreenFC<"MiniDAppStore"> = ({ navigation }) => {
           <View
             style={{
               paddingHorizontal: layout.spacing_x2,
-              minHeight: windowHeight - 170,
-              flex: 1,
+              minHeight:
+                Platform.OS === "android"
+                  ? windowHeight - 100
+                  : windowHeight - 210,
               justifyContent: "flex-end",
             }}
           >
@@ -55,12 +57,13 @@ export const DAppStoreScreen: ScreenFC<"MiniDAppStore"> = ({ navigation }) => {
         <CustomPressable
           onPress={toggleEnableEditingDApps}
           style={{
-            width: "100%",
             backgroundColor: blueDefault,
             paddingVertical: layout.spacing_x1_5,
             borderRadius: 100,
             position: "absolute",
-            bottom: 50,
+            bottom: 20,
+            width: windowWidth - 20,
+            alignSelf: "center",
           }}
         >
           <BrandText style={[fontSemibold15, { textAlign: "center" }]}>

--- a/packages/screens/Mini/layout/BlurScreenContainer.tsx
+++ b/packages/screens/Mini/layout/BlurScreenContainer.tsx
@@ -162,7 +162,7 @@ export const BlurScreenContainer = ({
                 <SVG source={chevronSVG} height={24} width={24} />
               </CustomPressable>
             )}
-            <BrandText style={[fontSemibold18, { lineHeight: 0 }]}>
+            <BrandText style={[fontSemibold18, { lineHeight: 22 }]}>
               {title || "Settings"}
             </BrandText>
 


### PR DESCRIPTION
![Screenshot_2024-03-25-15-12-31-973_host exp exponent](https://github.com/TERITORI/teritori-dapp/assets/154645503/6927a272-021d-416d-8a8a-82a091f9f1c9)
![Screenshot_2024-03-25-15-18-47-516_host exp exponent](https://github.com/TERITORI/teritori-dapp/assets/154645503/5670b0be-f449-443f-b4bd-077c963eb9c0)
