### PR TITLE
fix: governance details page title

### DIFF
--- a/packages/screens/Governance/GovernanceProposal/GovernanceProposalScreen.tsx
+++ b/packages/screens/Governance/GovernanceProposal/GovernanceProposalScreen.tsx
@@ -28,7 +28,7 @@ export const GovernanceProposalScreen: ScreenFC<"GovernanceProposal"> = ({
     "#" + proposal?.proposal_id + " " + proposal?.content.title;
   useEffect(() => {
     navigation.setOptions({
-      title: `Teritori - Governance : ${headerTitle || ""}`,
+      title: `Teritori - Governance: ${headerTitle || ""}`,
     });
   }, [navigation, id, headerTitle]);
 

--- a/packages/screens/Governance/GovernanceProposal/GovernanceProposalScreen.tsx
+++ b/packages/screens/Governance/GovernanceProposal/GovernanceProposalScreen.tsx
@@ -1,5 +1,5 @@
 import moment from "moment";
-import React from "react";
+import React, { useEffect } from "react";
 import { View } from "react-native";
 
 import { GovernanceDescription } from "./GovernanceDescription/GovernanceDescription";
@@ -24,6 +24,13 @@ export const GovernanceProposalScreen: ScreenFC<"GovernanceProposal"> = ({
   const selectedNetworkId = useSelectedNetworkId();
   const navigation = useAppNavigation();
   const proposal = useGetProposal(selectedNetworkId, id);
+  const headerTitle =
+    "#" + proposal?.proposal_id + " " + proposal?.content.title;
+  useEffect(() => {
+    navigation.setOptions({
+      title: `Teritori - Governance : ${headerTitle || ""}`,
+    });
+  }, [navigation, id, headerTitle]);
 
   return (
     <ScreenContainer


### PR DESCRIPTION
governance details page title issue fixed by setting the title of the metadata by using navigation.setOptions in GovernanceProposalScreen. 
![Screenshot 2024-03-26 at 4 34 27 PM](https://github.com/TERITORI/teritori-dapp/assets/134677881/64c1d2ea-bd56-486a-b77a-2107a5ec12b1)
