### PR TITLE
fix: dropdown crop issue on account list of mobile

### DIFF
--- a/packages/screens/Mini/Profile/ProfileScreen.tsx
+++ b/packages/screens/Mini/Profile/ProfileScreen.tsx
@@ -143,6 +143,7 @@ export const ProfileScreen: ScreenFC<"MiniProfile"> = ({ navigation }) => {
               </Pressable>
             );
           }}
+          contentContainerStyle={{ flexGrow: 1 }}
         />
 
         <Separator />


### PR DESCRIPTION
![Screenshot_1711692702](https://github.com/TERITORI/teritori-dapp/assets/154412187/d5c1458c-e682-4fdc-855b-1bbfe6bb4630)
![Screenshot_1711692711](https://github.com/TERITORI/teritori-dapp/assets/154412187/3cefe7b1-d441-487a-9d2a-df99650f744c)
![Screenshot_1711692786](https://github.com/TERITORI/teritori-dapp/assets/154412187/a2438744-502f-4a5d-9eb7-26b0595632da)
![Screenshot_1711692790](https://github.com/TERITORI/teritori-dapp/assets/154412187/b333326c-8121-473c-937e-8b153eaaf095)


The list of multiple account on mobile application side, there is crop issue on show dropdown,
when we have a one account, the first first account have facing crop issue, but we have multiple account then the last account of list have a crop issue, at the end of last item of list have a facing issue


issue resolved, Thanks.