### PR TITLE
fix: add a default pattern error on TextInputCustom

### DIFF
--- a/packages/components/inputs/TextInputCustom.tsx
+++ b/packages/components/inputs/TextInputCustom.tsx
@@ -184,9 +184,12 @@ export const TextInputCustom = <T extends FieldValues>({
       if (fieldState.error.message) {
         return fieldState.error.message;
       }
+      if (rules?.pattern && field.value) {
+        return DEFAULT_FORM_ERRORS.pattern;
+      }
       return DEFAULT_FORM_ERRORS.required;
     }
-  }, [fieldState.error]);
+  }, [fieldState.error, field.value]);
 
   // FIXME: the first input does not trigger the custom validation
 

--- a/packages/components/inputs/TextInputCustomBorder.tsx
+++ b/packages/components/inputs/TextInputCustomBorder.tsx
@@ -10,6 +10,8 @@ import {
 import { neutral22, neutral33 } from "../../utils/style/colors";
 import { SVG } from "../SVG";
 
+import { NUMBERS_REGEXP } from "@/utils/regex";
+
 // A custom TextInput. You can add children (Ex: An icon or a small container)
 export const TextInputCustomBorder: React.FC<{
   value: string;
@@ -39,7 +41,7 @@ export const TextInputCustomBorder: React.FC<{
       if (onlyNumbers) {
         const withoutCommaValue = thousandSeparatedToNumber(value);
         // Set value only if fully number
-        const reg = new RegExp(/^\d+$/);
+        const reg = new RegExp(NUMBERS_REGEXP);
         if (reg.test(withoutCommaValue)) {
           onChangeText(numberWithThousandsSeparator(withoutCommaValue));
         }

--- a/packages/screens/Launchpad/MintCollectionScreen.tsx
+++ b/packages/screens/Launchpad/MintCollectionScreen.tsx
@@ -60,6 +60,7 @@ import { prettyPrice } from "@/utils/coins";
 import { MintPhase } from "@/utils/collection";
 import { getMetaMaskEthereumSigner } from "@/utils/ethereum";
 import { ScreenFC } from "@/utils/navigation";
+import { NUMBERS_REGEXP } from "@/utils/regex";
 import {
   neutral17,
   neutral22,
@@ -131,7 +132,7 @@ export const MintCollectionScreen: ScreenFC<"MintCollection"> = ({
   const mintButtonDisabled = minted;
 
   const updateTotalBulkMint = (newTotalBulkMint: number | string) => {
-    const numOnlyRegexp = new RegExp(/^\d+$/);
+    const numOnlyRegexp = new RegExp(NUMBERS_REGEXP);
     if (!numOnlyRegexp.test("" + newTotalBulkMint)) {
       return;
     }

--- a/packages/screens/Multisig/MultisigCreateScreen.tsx
+++ b/packages/screens/Multisig/MultisigCreateScreen.tsx
@@ -29,6 +29,7 @@ import {
   validateAddress,
   validateMaxNumber,
 } from "@/utils/formRules";
+import { NUMBERS_REGEXP } from "@/utils/regex";
 import {
   neutral33,
   neutral77,
@@ -204,6 +205,7 @@ export const MultisigCreateScreen = () => {
             label="Multisig name"
             rules={{
               required: true,
+              pattern: NUMBERS_REGEXP,
             }}
             placeHolder="Type the name of the multisig"
             iconSVG={walletInputSVG}

--- a/packages/utils/errors.ts
+++ b/packages/utils/errors.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_FORM_ERRORS = {
   required: "This field is required",
+  pattern: "Invalid value",
 };
 
 export const DETAULT_PROCESS_ERROR =

--- a/packages/utils/formRules.ts
+++ b/packages/utils/formRules.ts
@@ -1,6 +1,8 @@
 import { bech32 } from "bech32";
 import { ValidationRule } from "react-hook-form";
 
+import { LETTERS_REGEXP, NUMBERS_REGEXP } from "@/utils/regex";
+
 // validator should return false or string to trigger error
 export const validateAddress = (value: string) => {
   try {
@@ -13,12 +15,12 @@ export const validateAddress = (value: string) => {
 };
 
 export const patternOnlyLetters: ValidationRule<RegExp> = {
-  value: /^[A-Za-z]+$/,
+  value: LETTERS_REGEXP,
   message: "Only letters are allowed",
 };
 
 export const patternOnlyNumbers: ValidationRule<RegExp> = {
-  value: /^\d+$/,
+  value: NUMBERS_REGEXP,
   message: "Only numbers are allowed",
 };
 

--- a/packages/utils/regex.ts
+++ b/packages/utils/regex.ts
@@ -3,3 +3,5 @@ export const URL_REGEX =
   /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/;
 export const HASHTAG_REGEX = /#\S+/;
 export const HTML_TAG_REGEXP = /(<([^>]+)>)/gi;
+export const NUMBERS_REGEXP = /^\d+$/;
+export const LETTERS_REGEXP = /^[A-Za-z]+$/;


### PR DESCRIPTION
### This will add a control on the value. We specify a `Regexp` as `pattern`
```
  <TextInputCustom
    rules={{
      pattern: NUMBERS_REGEXP
    }}
```
So, I added a defaut error message here : https://github.com/TERITORI/teritori-dapp/blob/6e37067342a144f0fa5de19463b149d06110044f/packages/utils/errors.ts#L3
Handled here (Triggered if `fieldState.error`) : https://github.com/TERITORI/teritori-dapp/blob/6e37067342a144f0fa5de19463b149d06110044f/packages/components/inputs/TextInputCustom.tsx#L187-L189
![image](https://github.com/TERITORI/teritori-dapp/assets/50441633/7e98a05c-225d-4ab1-8cd3-82f680999575)

### And this will add a control on the value AND a custom error message. We specify a `ValidationRule<RegExp>` as `pattern`
```
  <TextInputCustom
    rules={{
      pattern: patternOnlyNumbers
    }}
```
Default behavior, the error message is specified in the `ValidationRule<RegExp>`
![image](https://github.com/TERITORI/teritori-dapp/assets/50441633/ba64fea8-19e0-4cd1-ad81-99ea3ff0d027)
