### PR TITLE
fix: Add a property to match a RemoteFileData and a LocalFileData

### DIFF
--- a/packages/hooks/useIpfs.ts
+++ b/packages/hooks/useIpfs.ts
@@ -8,7 +8,7 @@ import { useSelector } from "react-redux";
 import { parseUserId } from "@/networks";
 import { selectNFTStorageAPI } from "@/store/slices/settings";
 import { generateIpfsKey } from "@/utils/ipfs";
-import { LocalFileData, RemoteFileData } from "@/utils/types/files";
+import { LocalFileData, RemoteFileDataWithLocalUrl } from "@/utils/types/files";
 
 interface UploadPostFilesToPinataParams {
   files: LocalFileData[];
@@ -84,12 +84,14 @@ export const useIpfs = () => {
     async ({
       files,
       pinataJWTKey,
-    }: UploadPostFilesToPinataParams): Promise<RemoteFileData[]> => {
+    }: UploadPostFilesToPinataParams): Promise<
+      RemoteFileDataWithLocalUrl[]
+    > => {
       setIpfsUploadProgresses([]);
 
       const storedFile = async (
         file: LocalFileData,
-      ): Promise<RemoteFileData> => {
+      ): Promise<RemoteFileDataWithLocalUrl> => {
         const fileIpfsHash = await pinataPinFileToIPFS({
           file,
           pinataJWTKey,

--- a/packages/hooks/useIpfs.ts
+++ b/packages/hooks/useIpfs.ts
@@ -109,6 +109,7 @@ export const useIpfs = () => {
           return {
             ...omit(file, "file"),
             url,
+            localUrl: file.url,
             thumbnailFileData: {
               ...omit(file.thumbnailFileData, "file"),
               url: thumbnailUrl,
@@ -120,6 +121,7 @@ export const useIpfs = () => {
             // Thumbnails cannot have a thumbnail, so we set isThumbnailImage here
             isThumbnailImage: file.isThumbnailImage,
             url,
+            localUrl: file.url,
           };
         }
       };

--- a/packages/utils/types/files.ts
+++ b/packages/utils/types/files.ts
@@ -41,7 +41,11 @@ export interface LocalFileData extends BaseFileData {
 
 export const ZodRemoteFileData = z.object({
   ...ZodBaseFileData.shape,
-  localUrl: z.string().optional(),
   thumbnailFileData: ZodBaseFileData.optional(),
 });
 export type RemoteFileData = z.infer<typeof ZodRemoteFileData>;
+
+// Can be used to match LocalFileData and RemoteFileData
+export interface RemoteFileDataWithLocalUrl extends RemoteFileData {
+  localUrl?: string;
+}

--- a/packages/utils/types/files.ts
+++ b/packages/utils/types/files.ts
@@ -41,6 +41,7 @@ export interface LocalFileData extends BaseFileData {
 
 export const ZodRemoteFileData = z.object({
   ...ZodBaseFileData.shape,
+  localUrl: z.string().optional(),
   thumbnailFileData: ZodBaseFileData.optional(),
 });
 export type RemoteFileData = z.infer<typeof ZodRemoteFileData>;


### PR DESCRIPTION
When we upload files using `uploadFilesToPinata`, we cannot match the obtained `RemoteFileData[]` with the uploaded `LocalFileData[]`.

Example: 
- **This will not work, because `remoteFiles[index]` and `localFiles[index]` will not necessary match :**
```
const localFiles = myObjects.map(object => object.localFiles!!)
const remoteFiles = await uploadFilesToPinata({
  pinataJWTKey,
  files: localFiles 
})

const objectsWithIpfsHashes = myObjects.map((object, index) => {
  return {
    ...object,
    uploadedFileIpfsHash: remoteFiles[index].url
  }
})
```
- **This will work, because `remoteFile.localUrl` get the value of `localFile.url` after each field upload :**
```
const localFiles = myObjects.map(object => object.localFiles!!)
const remoteFiles = await uploadFilesToPinata({
  pinataJWTKey,
  files: localFiles
})

const objectsWithIpfsHashes = myObjects.map((object, index)=> {
  return {
    ...object,
    uploadedFileIpfsHash: remoteFiles.find(remoteFile => remoteFile.localUrl === localFiles[index].url).url
  }
})
```

___

- I tested by uploading multiple files once, I retrieve the same localUrl, so can match the local files and the remote ones.
- There is no influence to `thumbnailFileData`, because it's embedded in each remoteFile.
- I tested on few `uploadFilesToPinata` usages, and it's ok :)