### PR TITLE
fix: Controlled component considered as uncontrolled because no value

### DIFF
--- a/packages/components/inputs/TextInputCustom.tsx
+++ b/packages/components/inputs/TextInputCustom.tsx
@@ -226,7 +226,7 @@ export const TextInputCustom = <T extends FieldValues>({
         onChangeText={handleChangeText}
         onKeyPress={(event) => handleKeyPress({ event, onPressEnter })}
         placeholderTextColor={neutralA3}
-        value={field.value}
+        value={field.value || ""}
         style={[styles.textInput, textInputStyle]}
         {...restProps}
       />
@@ -296,7 +296,7 @@ export const TextInputCustom = <T extends FieldValues>({
               onChangeText={handleChangeText}
               onKeyPress={(event) => handleKeyPress({ event, onPressEnter })}
               placeholderTextColor={neutral77}
-              value={field.value}
+              value={field.value || ""}
               style={[styles.textInput, textInputStyle]}
               {...restProps}
             />


### PR DESCRIPTION
Fixes this error :
`Warning: A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components`

(Btw `defaultValue` should be named `forcedValue` when I see its usage in `TextInputCustom` IMO)