### PR TITLE
hotfix: Prevent error on GovernanceScreen

### DIFF
--- a/packages/screens/Governance/GovernanceScreen.tsx
+++ b/packages/screens/Governance/GovernanceScreen.tsx
@@ -77,10 +77,12 @@ export const GovernanceScreen: React.FC = () => {
         }}
       >
         {filteredProposals
-          .filter((value) =>
-            value.content.title
-              .toLowerCase()
-              .includes(searchInput.toLowerCase()),
+          .filter(
+            (value) =>
+              value.content.title &&
+              value.content.title
+                .toLowerCase()
+                .includes(searchInput.toLowerCase()),
           )
           .map((proposals) => (
             <GovernanceBox proposal={proposals} isMobile={isMobile} />


### PR DESCRIPTION
It doesn't display the Proposals that have no title 