### PR TITLE
fix: mobile ci

### DIFF
--- a/.github/workflows/mobile-build-android.yml
+++ b/.github/workflows/mobile-build-android.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/mobile-build-ios.yml
+++ b/.github/workflows/mobile-build-ios.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Select xcode
         run: sudo xcode-select -s /Applications/Xcode_15.2.app

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ node_modules: package.json yarn.lock
 .PHONY: go-mod-tidy
 go-mod-tidy:
 	go mod tidy
-	cd ./weshd && go mod tidy
 
 .PHONY: generate
 generate: generate.protobuf generate.graphql generate.contracts-clients generate.go-networks networks.json

--- a/weshd/go.mod
+++ b/weshd/go.mod
@@ -1,6 +1,6 @@
 module weshd
 
-go 1.19
+go 1.20
 
 require (
 	berty.tech/weshnet v1.14.0


### PR DESCRIPTION
- Used go 1.20 for ./weshd only
- go 1.20 is used for mobile builds GitHub actions (android and ios)