### PR TITLE
feat(deploy-scripts): args for deployDA0DA0 + cross-platform home + deploy DA0DA0 on testnet

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -11141,13 +11141,13 @@
       ""
     ],
     "socialFeedContractAddress": "tori1mf6ptkssddfmxvhdx0ech0k03ktp6kf9yk59renau2gvht3nq2gqg87tkw",
-    "daoCoreCodeId": -1,
-    "daoPreProposeSingleCodeId": -1,
-    "daoProposalSingleCodeId": -1,
-    "cw4GroupCodeId": -1,
-    "daoVotingCw4CodeId": -1,
-    "cwAdminFactoryCodeId": -1,
-    "cwAdminFactoryContractAddress": ""
+    "daoCoreCodeId": 30,
+    "daoPreProposeSingleCodeId": 32,
+    "daoProposalSingleCodeId": 33,
+    "cw4GroupCodeId": 28,
+    "daoVotingCw4CodeId": 31,
+    "cwAdminFactoryCodeId": 29,
+    "cwAdminFactoryContractAddress": "tori1du6yg34tljg54s5qhsqv2ay23nx7cqjmku2yuv0fs4namz7yn9yqep8rde"
   },
   {
     "id": "cosmos-registry:terpnettestnet",

--- a/packages/networks/teritori-testnet/index.ts
+++ b/packages/networks/teritori-testnet/index.ts
@@ -92,11 +92,12 @@ export const teritoriTestnetNetwork: CosmosNetworkInfo = {
   excludeFromLaunchpadList: [riotContractAddressGen1],
   socialFeedContractAddress:
     "tori1mf6ptkssddfmxvhdx0ech0k03ktp6kf9yk59renau2gvht3nq2gqg87tkw",
-  daoCoreCodeId: -1,
-  daoPreProposeSingleCodeId: -1,
-  daoProposalSingleCodeId: -1,
-  cw4GroupCodeId: -1,
-  daoVotingCw4CodeId: -1,
-  cwAdminFactoryCodeId: -1,
-  cwAdminFactoryContractAddress: "",
+  daoCoreCodeId: 30,
+  daoPreProposeSingleCodeId: 32,
+  daoProposalSingleCodeId: 33,
+  cw4GroupCodeId: 28,
+  daoVotingCw4CodeId: 31,
+  cwAdminFactoryCodeId: 29,
+  cwAdminFactoryContractAddress:
+    "tori1du6yg34tljg54s5qhsqv2ay23nx7cqjmku2yuv0fs4namz7yn9yqep8rde",
 };

--- a/packages/scripts/network-setup/deploy.ts
+++ b/packages/scripts/network-setup/deploy.ts
@@ -1,4 +1,6 @@
 import { program } from "commander";
+import os from "os";
+import path from "path";
 
 import { deployTeritoriEcosystem } from "./deployLib";
 
@@ -9,7 +11,11 @@ const main = async () => {
   const [networkId, wallet] = program.args;
 
   const network = await deployTeritoriEcosystem(
-    { home: "~/.teritorid", binaryPath: "teritorid", signer: undefined },
+    {
+      home: path.join(os.homedir(), ".teritorid"),
+      binaryPath: "teritorid",
+      signer: undefined,
+    },
     networkId,
     wallet,
   );

--- a/packages/scripts/network-setup/deployLib.ts
+++ b/packages/scripts/network-setup/deployLib.ts
@@ -290,7 +290,7 @@ export const instantiateNameService = async (
 };
 
 export const instantiateContract = async (
-  opts: { home: string; binaryPath: string },
+  opts: { home: string; binaryPath: string; keyringBackend?: string },
   wallet: string,
   network: CosmosNetworkInfo,
   codeId: number,
@@ -304,7 +304,7 @@ export const instantiateContract = async (
     network.chainId
   } --node ${injectRPCPort(
     network.rpcEndpoint,
-  )} --yes --keyring-backend test -o json --label ${sqh(
+  )} --yes --keyring-backend ${opts.keyringBackend || "test"} -o json --label ${sqh(
     label,
   )} --admin ${admin} --home ${opts.home}`;
   console.log("⚙️  " + cmd);

--- a/packages/scripts/network-setup/restoreContract.ts
+++ b/packages/scripts/network-setup/restoreContract.ts
@@ -1,5 +1,7 @@
 import { program } from "commander";
 import fs from "fs";
+import os from "os";
+import path from "path";
 
 import { storeWASM } from "./deployLib";
 import {
@@ -46,7 +48,11 @@ const main = async () => {
   fs.writeFileSync(contractPath, contractBytes);
 
   const codeId = await storeWASM(
-    { home: "~/.teritorid", binaryPath: "teritorid", keyringBackend },
+    {
+      home: path.join(os.homedir(), ".teritorid"),
+      binaryPath: "teritorid",
+      keyringBackend,
+    },
     wallet,
     destinationNetwork,
     contractPath,


### PR DESCRIPTION
Can now execute `deployDA0DA0.ts` with these args:
- `network-id` (required)
- `wallet` (required)
- `--keyring-backend` (optionnal)

https://github.com/TERITORI/teritori-dapp/pull/1234/files#diff-75c9ee642dbd4a76e719d9c6bb35e840757a47dad676728fe0bf383284c11177R197-R216

Can now specify `--keyringBackend` when calling `instantiateContract`
https://github.com/TERITORI/teritori-dapp/pull/1234/files#diff-75c9ee642dbd4a76e719d9c6bb35e840757a47dad676728fe0bf383284c11177R159

Better cross-plateform `home`
https://github.com/TERITORI/teritori-dapp/pull/1234/files#diff-a844341e6901a2d16b286101bec6bb725e1f5b5cfb98fff16edca1759fb10695R15

I used this to deploy DAO stuff on teritori-testnet:
`npx tsx teritori-dapp/packages/scripts/network-setup/deployDA0DA0.ts teritori-testnet wallet --keyring-backend=os`

And I completed teritori-testnet network
https://github.com/TERITORI/teritori-dapp/pull/1234/files#diff-8a32852e352262824c4f193cc6b8517a68bdc87d0d28a534b99ac9df80a867f3R11144-R11150
https://github.com/TERITORI/teritori-dapp/pull/1234/files#diff-a95ecdfb0d932b9fe4f6cabbe4cebafcd9482a393bc337a5bd7b769f43f25767R95-R102