### PR TITLE
feat: mark gifs as PostCategory.Picture

### DIFF
--- a/packages/utils/feed/queries.ts
+++ b/packages/utils/feed/queries.ts
@@ -98,27 +98,22 @@ export const getPostCategory = ({
   message,
   gifs,
 }: NewPostFormValues): PostCategory => {
-  let category: PostCategory;
-  if (gifs?.length) {
-    category = PostCategory.Picture;
-  } else if (files?.length) {
-    if (files[0].fileType === "image") {
-      category = PostCategory.Picture;
-    } else if (files[0].fileType === "audio") {
-      category = PostCategory.Audio;
-    } else {
-      category = PostCategory.VideoNote;
+  if (gifs?.length) return PostCategory.Picture;
+  if (files?.length) {
+    switch (files[0].fileType) {
+      case "image":
+        return PostCategory.Picture;
+      case "audio":
+        return PostCategory.Audio;
+      default:
+        return PostCategory.VideoNote;
     }
-  } else if (title) {
-    category = PostCategory.Article;
-  } else if (message.startsWith("/question")) {
-    category = PostCategory.Question;
-  } else if (message.startsWith("/generate")) {
-    category = PostCategory.BriefForStableDiffusion;
-  } else {
-    category = PostCategory.Normal;
   }
-  return category;
+  if (title) return PostCategory.Article;
+  if (message.startsWith("/question")) return PostCategory.Question;
+  if (message.startsWith("/generate"))
+    return PostCategory.BriefForStableDiffusion;
+  return PostCategory.Normal;
 };
 
 interface GeneratePostMetadataParams extends Omit<NewPostFormValues, "files"> {

--- a/packages/utils/feed/queries.ts
+++ b/packages/utils/feed/queries.ts
@@ -96,9 +96,12 @@ export const getPostCategory = ({
   title,
   files,
   message,
+  gifs,
 }: NewPostFormValues): PostCategory => {
   let category: PostCategory;
-  if (files?.length) {
+  if (gifs?.length) {
+    category = PostCategory.Picture;
+  } else if (files?.length) {
     if (files[0].fileType === "image") {
       category = PostCategory.Picture;
     } else if (files[0].fileType === "audio") {


### PR DESCRIPTION
Posts with GIFs get now the `PostCategory` `Picture`, and are visible in Pics Feed
![image](https://github.com/user-attachments/assets/f39c6365-1de5-43f9-a582-54a32353f4f6)
![image](https://github.com/user-attachments/assets/cff7d712-e914-4c05-9b0b-b1e0c57c1f31)

Users can make posts with only GIFs and no text, as with images files. So, it makes sense to treat these two case as same `PostCategory`

---
Also, I need that for the Map Feed, to correctly display the GIFs as `Picture` posts on the map. 
![image](https://github.com/user-attachments/assets/1b9b9e05-6c32-4afb-ac69-b34b0f94ab65)
If not, the posts with GIFs will appear as `Normal` posts with empty content (Because the text is not mandatory)
![image](https://github.com/user-attachments/assets/9e25acbe-b94d-4366-a232-7c5d486b1e7d)
