### PR TITLE
Feat: Make hash available in addition to CID when using IPFS

### DIFF
--- a/packages/components/teritoriNameService/MediaPreview.tsx
+++ b/packages/components/teritoriNameService/MediaPreview.tsx
@@ -68,11 +68,11 @@ export const MediaPreview: React.FC<{
       return;
     }
     if (documentPickerResult.output) {
-      const fileIpfsHash = await pinataPinFileToIPFS({
+      const pinFileToIPFSResult = await pinataPinFileToIPFS({
         pinataJWTKey,
         file: { file: documentPickerResult.output[0] },
       } as PinataFileProps);
-      callback(`ipfs://${fileIpfsHash}`);
+      callback(`ipfs://${pinFileToIPFSResult?.ipfsCid || ""}`);
     }
   };
 

--- a/packages/utils/types/files.ts
+++ b/packages/utils/types/files.ts
@@ -31,6 +31,7 @@ const ZodBaseFileData = z.object({
   isCoverImage: z.boolean().optional(),
   isThumbnailImage: z.boolean().optional(),
   base64Image: z.string().optional(),
+  hash: z.string().optional(),
 });
 type BaseFileData = z.infer<typeof ZodBaseFileData>;
 


### PR DESCRIPTION
### Before
`useIpfs` allows to get the CID of uploaded files

![image](https://github.com/user-attachments/assets/75326fa1-0784-49bf-b250-5e510e576672)
Our files types embed this CID as `url`

![image](https://github.com/user-attachments/assets/5bd221b5-9b8f-4596-8122-6c4fcdff1473)


### After
`useIpfs` allows to get the CID and the hash (before parsing it to CID) of uploaded files

![image](https://github.com/user-attachments/assets/7fb90bab-c021-4f93-991a-9258b92e62b2)
Our files types embed the CID as `url` and the hash as `hash`

![image](https://github.com/user-attachments/assets/077a7b3a-6fbe-417e-909b-7e4611b4feee)

