### PR TITLE
fix: set a prop as optional and remove usage

### DIFF
--- a/packages/components/table/TableWrapper.tsx
+++ b/packages/components/table/TableWrapper.tsx
@@ -6,7 +6,7 @@ import { SpacerColumn } from "@/components/spacer";
 
 export const TableWrapper: FC<{
   children: ReactNode;
-  paginationProps: PaginationProps;
+  paginationProps?: PaginationProps;
   showPagination?: boolean;
   horizontalScrollBreakpoint?: number;
 }> = ({
@@ -31,7 +31,7 @@ export const TableWrapper: FC<{
         </View>
       </ScrollView>
 
-      {showPagination && (
+      {showPagination && paginationProps && (
         <>
           <SpacerColumn size={2} />
           <Pagination {...paginationProps} />

--- a/packages/screens/LaunchpadERC20/component/LaunchpadERC20AirdropsTable.tsx
+++ b/packages/screens/LaunchpadERC20/component/LaunchpadERC20AirdropsTable.tsx
@@ -69,17 +69,7 @@ export const AirdropsTable: React.FC<AirdropsTableProps> = ({ networkId }) => {
     >
       <BrandText>Latest ERC20 Airdrops Created</BrandText>
       <SpacerColumn size={2} />
-      <TableWrapper
-        paginationProps={{
-          currentPage: 0,
-          maxPage: 1,
-          itemsPerPage: 10,
-          nbItemsOptions: [],
-          setItemsPerPage: () => {},
-          onChangePage: () => {},
-        }}
-        horizontalScrollBreakpoint={breakpointM}
-      >
+      <TableWrapper horizontalScrollBreakpoint={breakpointM}>
         <TableHeader columns={columns} />
         {airdrops && (
           <FlatList

--- a/packages/screens/LaunchpadERC20/component/LaunchpadERC20SalesTable.tsx
+++ b/packages/screens/LaunchpadERC20/component/LaunchpadERC20SalesTable.tsx
@@ -75,17 +75,7 @@ export const SalesTable: React.FC<SalesTableProps> = ({ networkId }) => {
     >
       <BrandText>Latest ERC20 Sales Created</BrandText>
       <SpacerColumn size={2} />
-      <TableWrapper
-        paginationProps={{
-          currentPage: 0,
-          maxPage: 1,
-          itemsPerPage: 10,
-          nbItemsOptions: [],
-          setItemsPerPage: () => {},
-          onChangePage: () => {},
-        }}
-        horizontalScrollBreakpoint={breakpointM}
-      >
+      <TableWrapper horizontalScrollBreakpoint={breakpointM}>
         <TableHeader columns={columns} />
         {sales && (
           <FlatList

--- a/packages/screens/LaunchpadERC20/component/LaunchpadERC20TokensTable.tsx
+++ b/packages/screens/LaunchpadERC20/component/LaunchpadERC20TokensTable.tsx
@@ -69,17 +69,7 @@ export const TokensTable: React.FC<TokensTableProps> = ({ networkId }) => {
     >
       <BrandText>Latest ERC20 Tokens Created</BrandText>
       <SpacerColumn size={2} />
-      <TableWrapper
-        paginationProps={{
-          currentPage: 0,
-          maxPage: 1,
-          itemsPerPage: 10,
-          nbItemsOptions: [],
-          setItemsPerPage: () => {},
-          onChangePage: () => {},
-        }}
-        horizontalScrollBreakpoint={breakpointM}
-      >
+      <TableWrapper horizontalScrollBreakpoint={breakpointM}>
         <TableHeader columns={columns} />
         {tokens && (
           <FlatList

--- a/packages/screens/MarketplaceLeaderboardScreen/component/MarketplaceLeaderboardTable.tsx
+++ b/packages/screens/MarketplaceLeaderboardScreen/component/MarketplaceLeaderboardTable.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import React, { useState } from "react";
+import React from "react";
 import { FlatList, View } from "react-native";
 
 import { screenContentMaxWidthLarge } from "../../../utils/style/layout";
@@ -59,18 +59,13 @@ export const MarketplaceLeaderboardTable: React.FC<{
   networkId: string | undefined;
   timePeriodHours: number;
 }> = React.memo(({ networkId, timePeriodHours }) => {
-  const [pageIndex, setPageIndex] = useState(0);
-  const [itemsPerPage, setItemsPerPage] = useState(100);
   const { data: leaderboard } = useMarketplaceLeaderboard(
     networkId,
     timePeriodHours,
   );
 
-  // NOTE: we only show the first 100 items, because getting the total count to properly find maxPage will slow the query down
+  // NOTE: we only show the first 100 items (limit from backend), because getting the total count to properly find maxPage will slow the query down
   // see https://stackoverflow.com/questions/28888375/run-a-query-with-a-limit-offset-and-also-get-the-total-number-of-rows
-
-  const numItems = leaderboard?.length || 0;
-  const maxPage = Math.max(Math.ceil(numItems / itemsPerPage), 1);
 
   return (
     <View
@@ -79,17 +74,7 @@ export const MarketplaceLeaderboardTable: React.FC<{
         maxWidth: screenContentMaxWidthLarge,
       }}
     >
-      <TableWrapper
-        horizontalScrollBreakpoint={breakpointM}
-        paginationProps={{
-          currentPage: pageIndex,
-          maxPage,
-          itemsPerPage,
-          nbItemsOptions: [100],
-          setItemsPerPage,
-          onChangePage: setPageIndex,
-        }}
-      >
+      <TableWrapper horizontalScrollBreakpoint={breakpointM}>
         <TableHeader columns={columns} />
         <FlatList
           data={leaderboard}


### PR DESCRIPTION
It allows to use `TableWrapper` without `paginationProps` that is useless if `showPagination` is not used.
So I also removed useless `paginationProps` usages