### PR TITLE
fix(feed): Allow to focus Article Editor by clicking the placeholder

### DIFF
--- a/packages/components/socialFeed/RichText/RichText.web.tsx
+++ b/packages/components/socialFeed/RichText/RichText.web.tsx
@@ -436,7 +436,9 @@ export const RichText: React.FC<RichTextProps> = ({
       <ScrollView
         contentContainerStyle={isTruncateNeeded && { overflow: "hidden" }}
       >
-        <TouchableWithoutFeedback onPress={handlePressEditor}>
+        <TouchableWithoutFeedback
+          onPress={!isPostConsultation ? handlePressEditor : undefined}
+        >
           <View>
             <Editor
               editorState={editorState}

--- a/packages/components/socialFeed/RichText/RichText.web.tsx
+++ b/packages/components/socialFeed/RichText/RichText.web.tsx
@@ -38,7 +38,13 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { ScrollView, useWindowDimensions, View, ViewStyle } from "react-native";
+import {
+  ScrollView,
+  TouchableWithoutFeedback,
+  useWindowDimensions,
+  View,
+  ViewStyle,
+} from "react-native";
 
 import { RichHashtagRenderer } from "./RichRenderer/RichHashtagRenderer";
 import { RichHashtagRendererConsultation } from "./RichRenderer/RichHashtagRendererConsultation";
@@ -313,6 +319,13 @@ export const RichText: React.FC<RichTextProps> = ({
     onPublish?.(publishValues);
   };
 
+  // Focuses Editor
+  const handlePressEditor = () => {
+    if (editorRef.current) {
+      editorRef.current.focus();
+    }
+  };
+
   /////////////// TOOLBAR BUTTONS ////////////////
   const Buttons: React.FC<{ externalProps: any }> = ({ externalProps }) => (
     <View style={toolbarButtonsWrapperCStyle}>
@@ -423,18 +436,22 @@ export const RichText: React.FC<RichTextProps> = ({
       <ScrollView
         contentContainerStyle={isTruncateNeeded && { overflow: "hidden" }}
       >
-        <Editor
-          editorState={editorState}
-          handleKeyCommand={handleKeyCommand}
-          keyBindingFn={keyBindingFn}
-          onChange={handleChange}
-          plugins={plugins}
-          placeholder={isPostConsultation ? "" : "Type message here"}
-          readOnly={isPostConsultation}
-          onBlur={onBlur}
-          ref={editorRef}
-          decorators={compositeDecorator.decorators}
-        />
+        <TouchableWithoutFeedback onPress={handlePressEditor}>
+          <View>
+            <Editor
+              editorState={editorState}
+              handleKeyCommand={handleKeyCommand}
+              keyBindingFn={keyBindingFn}
+              onChange={handleChange}
+              plugins={plugins}
+              placeholder={isPostConsultation ? "" : "Type message here"}
+              readOnly={isPostConsultation}
+              onBlur={onBlur}
+              ref={editorRef}
+              decorators={compositeDecorator.decorators}
+            />
+          </View>
+        </TouchableWithoutFeedback>
         {isTruncateNeeded && (
           <BrandText style={[fontSemibold14, { color: neutral77 }]}>
             {"\n...see more"}


### PR DESCRIPTION
Actually, when the user clicks on "Type message here", it does nothing.
It's just a placeholder, so we expect that focuses the editor, and lets the user type.

![image](https://github.com/user-attachments/assets/74802143-d968-441a-9329-a63a103a00dc)

This weird behavior is due to the fact `placheloder` from `draft-js` `Editor` is a `div`
![image](https://github.com/user-attachments/assets/a63fcc26-eeae-4718-bde0-e825f08cc1bb)

So I added a `TouchableWithoutFeedback` that focuses the `Editor` when `onPress`
