### PR TITLE
fix(feed): Fix Tip action and TipModal

### DIFF
--- a/packages/components/socialFeed/SocialActions/TipButton.tsx
+++ b/packages/components/socialFeed/SocialActions/TipButton.tsx
@@ -113,7 +113,7 @@ export const TipButton: React.FC<{
               amount={tipAmountLocal}
             />
           ) : (
-            <TeritoriTipAmount amount={amount} />
+            <TeritoriTipAmount amount={tipAmountLocal} />
           )}
         </BrandText>
       </TouchableOpacity>
@@ -121,9 +121,13 @@ export const TipButton: React.FC<{
       <TipModal
         authorId={authorId}
         postId={postId}
-        onClose={(newTipAmount: number | undefined) => {
+        onClose={(addedTipAmount: number | undefined) => {
           setTipModalVisible(false);
-          newTipAmount && setTipAmountLocal(amount + newTipAmount);
+          addedTipAmount &&
+            setTipAmountLocal(
+              (typeof amount !== "number" ? parseInt(amount, 10) : amount) +
+                addedTipAmount,
+            );
         }}
         isVisible={tipModalVisible}
       />

--- a/packages/components/socialFeed/SocialActions/TipButton.tsx
+++ b/packages/components/socialFeed/SocialActions/TipButton.tsx
@@ -123,11 +123,7 @@ export const TipButton: React.FC<{
         postId={postId}
         onClose={(addedTipAmount: number | undefined) => {
           setTipModalVisible(false);
-          addedTipAmount &&
-            setTipAmountLocal(
-              (typeof amount !== "number" ? parseInt(amount, 10) : amount) +
-                addedTipAmount,
-            );
+          addedTipAmount && setTipAmountLocal(amount + addedTipAmount);
         }}
         isVisible={tipModalVisible}
       />

--- a/packages/components/socialFeed/SocialActions/TipModal.tsx
+++ b/packages/components/socialFeed/SocialActions/TipModal.tsx
@@ -1,6 +1,6 @@
 import { coin } from "@cosmjs/amino";
 import { Decimal } from "@cosmjs/math";
-import React from "react";
+import React, { useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { View } from "react-native";
 
@@ -8,12 +8,16 @@ import { signingSocialFeedClient } from "../../../client-creators/socialFeedClie
 import { useFeedbacks } from "../../../context/FeedbacksProvider";
 import { useTeritoriSocialFeedTipPostMutation } from "../../../contracts-clients/teritori-social-feed/TeritoriSocialFeed.react-query";
 import { useBalances } from "../../../hooks/useBalances";
-import { useSelectedNetworkInfo } from "../../../hooks/useSelectedNetwork";
+import {
+  useSelectedNetworkId,
+  useSelectedNetworkInfo,
+} from "../../../hooks/useSelectedNetwork";
 import useSelectedWallet from "../../../hooks/useSelectedWallet";
 import {
   getStakingCurrency,
   keplrCurrencyFromNativeCurrencyInfo,
   NetworkKind,
+  parseNetworkObjectId,
 } from "../../../networks";
 import { prettyPrice } from "../../../utils/coins";
 import { defaultSocialFeedFee } from "../../../utils/fee";
@@ -40,38 +44,63 @@ type TipFormType = {
 export const TipModal: React.FC<{
   authorId: string;
   postId: string;
-  onClose: (newTipAmount?: number) => void;
+  onClose: (addedTipAmount?: number) => void;
   isVisible: boolean;
 }> = ({ authorId, postId, onClose, isVisible }) => {
+  const selectedNetworkId = useSelectedNetworkId();
+  const nativeCurrency = getStakingCurrency(selectedNetworkId);
   const {
     control,
     handleSubmit: formHandleSubmit,
     setValue,
     watch,
-  } = useForm<TipFormType>();
+  } = useForm<TipFormType>({
+    defaultValues: {
+      amount: "",
+    },
+  });
+  const formValues = watch();
+  const amount = nativeCurrency
+    ? Decimal.fromUserInput(formValues.amount, nativeCurrency.decimals).atomics
+    : "0";
   const { mutate: postMutate, isLoading } =
     useTeritoriSocialFeedTipPostMutation({
+      onMutate() {
+        setLocalLoading(true);
+      },
       onSuccess() {
-        onClose();
-        setToastSuccess({ title: "Tip success", message: "" });
+        setToast({
+          mode: "normal",
+          type: "success",
+          title: "Tip success",
+          message: "",
+        });
       },
       onError(error) {
         console.error(error);
-        setToastError({ title: "Tip failed", message: error.message });
+        setToast({
+          mode: "normal",
+          type: "error",
+          title: "Tip failed",
+          message: error.message,
+        });
+      },
+
+      onSettled() {
+        onClose(+amount);
+        setLocalLoading(false);
       },
     });
+  const [islocalLoading, setLocalLoading] = useState(isLoading);
   const selectedWallet = useSelectedWallet();
   const selectedNetworkInfo = useSelectedNetworkInfo();
-  const selectedNetworkId = selectedNetworkInfo?.id || "";
-  const nativeCurrency = getStakingCurrency(selectedNetworkId);
-  const { setToastError, setToastSuccess } = useFeedbacks();
+  const { setToast } = useFeedbacks();
   const { balances } = useBalances(selectedNetworkId, selectedWallet?.address);
   const currencyBalance = balances.find(
     (bal) => bal.denom === nativeCurrency?.denom,
   );
-  const formValues = watch();
 
-  const handleSubmit: SubmitHandler<TipFormType> = async (fieldValues) => {
+  const handleSubmit: SubmitHandler<TipFormType> = async () => {
     if (
       !selectedWallet?.connected ||
       !selectedWallet.address ||
@@ -79,11 +108,6 @@ export const TipModal: React.FC<{
     ) {
       return;
     }
-
-    const amount = Decimal.fromUserInput(
-      fieldValues.amount,
-      nativeCurrency.decimals,
-    ).atomics;
 
     if (selectedNetworkInfo?.kind === NetworkKind.Gno) {
       // We use Tip function from Social_feed contract to keep track of tip amount
@@ -96,6 +120,7 @@ export const TipModal: React.FC<{
       };
 
       try {
+        setLocalLoading(true);
         await adenaDoContract(
           selectedNetworkId || "",
           [{ type: AdenaDoContractMessageType.CALL, value: vmCall }],
@@ -104,11 +129,23 @@ export const TipModal: React.FC<{
           },
         );
 
-        onClose(+amount);
-        setToastSuccess({ title: "Tip success", message: "" });
+        setToast({
+          mode: "normal",
+          type: "success",
+          title: "Tip success",
+          message: "",
+        });
       } catch (err: any) {
         console.error(err);
-        setToastError({ title: "Tip failed", message: err.message });
+        setToast({
+          mode: "normal",
+          type: "error",
+          title: "Tip failed",
+          message: err.message,
+        });
+      } finally {
+        onClose(+amount);
+        setLocalLoading(false);
       }
     } else {
       const client = await signingSocialFeedClient({
@@ -119,7 +156,7 @@ export const TipModal: React.FC<{
       postMutate({
         client,
         msg: {
-          identifier: postId,
+          identifier: parseNetworkObjectId(postId)[1],
         },
         args: {
           fee: defaultSocialFeedFee,
@@ -186,7 +223,7 @@ export const TipModal: React.FC<{
           text="Send"
           fullWidth
           loader
-          isLoading={isLoading}
+          isLoading={islocalLoading}
           onPress={formHandleSubmit(handleSubmit)}
           disabled={
             max === "0" || !formValues.amount || formValues.amount === "0"

--- a/packages/components/socialFeed/SocialActions/TipModal.tsx
+++ b/packages/components/socialFeed/SocialActions/TipModal.tsx
@@ -36,7 +36,7 @@ import ModalBase from "../../modals/ModalBase";
 import { SpacerColumn } from "../../spacer";
 
 import { Username } from "@/components/user/Username";
-import { sanitizeFloatAmount } from "@/utils/text";
+import { sanitizeFloatText } from "@/utils/text";
 
 type TipFormType = {
   amount: string;
@@ -63,7 +63,7 @@ export const TipModal: React.FC<{
   const formValues = watch();
   const amount = nativeCurrency
     ? Decimal.fromUserInput(
-        sanitizeFloatAmount(formValues.amount),
+        sanitizeFloatText(formValues.amount),
         nativeCurrency.decimals,
       ).atomics
     : "0";

--- a/packages/components/socialFeed/SocialActions/TipModal.tsx
+++ b/packages/components/socialFeed/SocialActions/TipModal.tsx
@@ -36,6 +36,7 @@ import ModalBase from "../../modals/ModalBase";
 import { SpacerColumn } from "../../spacer";
 
 import { Username } from "@/components/user/Username";
+import { sanitizeFloatAmount } from "@/utils/text";
 
 type TipFormType = {
   amount: string;
@@ -61,8 +62,12 @@ export const TipModal: React.FC<{
   });
   const formValues = watch();
   const amount = nativeCurrency
-    ? Decimal.fromUserInput(formValues.amount, nativeCurrency.decimals).atomics
+    ? Decimal.fromUserInput(
+        sanitizeFloatAmount(formValues.amount),
+        nativeCurrency.decimals,
+      ).atomics
     : "0";
+
   const { mutate: postMutate, isLoading } =
     useTeritoriSocialFeedTipPostMutation({
       onMutate() {

--- a/packages/components/socialFeed/SocialActions/TipModal.tsx
+++ b/packages/components/socialFeed/SocialActions/TipModal.tsx
@@ -116,7 +116,7 @@ export const TipModal: React.FC<{
         send: `${amount}ugnot`,
         pkg_path: selectedNetworkInfo.socialFeedsPkgPath,
         func: "TipPost",
-        args: [TERITORI_FEED_ID, postId],
+        args: [TERITORI_FEED_ID, parseNetworkObjectId(postId)[1]],
       };
 
       try {

--- a/packages/hooks/feed/usePost.ts
+++ b/packages/hooks/feed/usePost.ts
@@ -71,7 +71,7 @@ export const usePost = (id: string | undefined) => {
           isDeleted: res.deleted,
           subPostLength: res.sub_post_length,
           createdAt,
-          tipAmount: res.tip_amount,
+          tipAmount: parseFloat(res.tip_amount),
           premiumLevel: commonMetadata?.premium || 0,
         };
         return post;

--- a/packages/utils/text.tsx
+++ b/packages/utils/text.tsx
@@ -32,3 +32,10 @@ export const replaceBetweenString = (
   insertion: string,
 ) =>
   `${origin.substring(0, startIndex)}${insertion}${origin.substring(endIndex)}`;
+
+export const sanitizeFloatAmount = (amount: string) => {
+  if (amount.endsWith(".")) {
+    return amount.slice(0, -1);
+  }
+  return amount;
+};

--- a/packages/utils/text.tsx
+++ b/packages/utils/text.tsx
@@ -33,8 +33,9 @@ export const replaceBetweenString = (
 ) =>
   `${origin.substring(0, startIndex)}${insertion}${origin.substring(endIndex)}`;
 
-export const sanitizeFloatAmount = (amount: string) => {
-  if (amount.endsWith(".")) {
+// Fix amount when missing the fractional part like "2." by removing the "."
+export const sanitizeFloatText = (amount: string) => {
+  if (isFloatText(amount) && amount.endsWith(".")) {
     return amount.slice(0, -1);
   }
   return amount;


### PR DESCRIPTION
### Fixes "Cannot tip"
Closes #1376 
Gno network: https://github.com/TERITORI/teritori-dapp/blob/fix-tip/packages/components/socialFeed/SocialActions/TipModal.tsx#L119
Other networks: https://github.com/TERITORI/teritori-dapp/blob/fix-tip/packages/components/socialFeed/SocialActions/TipModal.tsx#L159

![image](https://github.com/user-attachments/assets/0c10313b-6095-46ee-a29d-247d77e1c2c3)

### Fixes "the Tip amount is not refresh"
Closes #1389 
https://github.com/TERITORI/teritori-dapp/blob/fix-tip/packages/components/socialFeed/SocialActions/TipModal.tsx#L90

### Fixes a wrong Tip amount shown
`tipAmount` was a `string` here, so the `addedAmount` addition results on a broken number displayed
https://github.com/TERITORI/teritori-dapp/blob/fix-tip/packages/hooks/feed/usePost.ts#L74

I used the same pattern as here: https://github.com/TERITORI/teritori-dapp/blob/fix-tip/packages/utils/social-feed.ts#L123

![image](https://github.com/user-attachments/assets/c5da4c51-a132-445a-8ccf-281d480b160b)

### Fixes this loader that won't stop if the TX fails (Gno Tip also)
https://github.com/TERITORI/teritori-dapp/blob/fix-tip/packages/components/socialFeed/SocialActions/TipModal.tsx#L91

![image](https://github.com/user-attachments/assets/3d1564a2-81d1-4832-b218-819cfb8680a4)

### Fixes closing the TipModal, even if Tip fails, to let the Toast Error visible (Gno Tip also)
https://github.com/TERITORI/teritori-dapp/blob/fix-tip/packages/components/socialFeed/SocialActions/TipModal.tsx#L90

### Fixes this error
https://github.com/TERITORI/teritori-dapp/blob/fix-tip/packages/components/socialFeed/SocialActions/TipModal.tsx#L58-L60

![image](https://github.com/user-attachments/assets/8a36f934-9875-4d2a-b0d1-dda0541c3953)