### PR TITLE
fix: dao proposals query key

### DIFF
--- a/packages/hooks/dao/useDAOProposals.ts
+++ b/packages/hooks/dao/useDAOProposals.ts
@@ -51,7 +51,7 @@ export const useDAOProposals = (daoId: string | undefined) => {
   const { daoProposals: cosmWasmDAOProposals, ...cosmWasmOther } =
     useCosmWasmDAOProposals(daoId);
   const { data: gnoDAOProposals, ...gnoOther } = useQuery(
-    daoProposalsQueryKey(daoId),
+    [...daoProposalsQueryKey(daoId), "gno"],
     async () => {
       if (network?.kind !== NetworkKind.Gno) return [];
       const provider = new GnoJSONRPCProvider(network.endpoint);
@@ -93,7 +93,7 @@ const useCosmWasmDAOProposals = (daoId: string | undefined) => {
   const proposalModuleAddress = daoFirstProposalModule?.address;
 
   const { data, ...other } = useQuery(
-    daoProposalsQueryKey(daoId),
+    [...daoProposalsQueryKey(daoId), "cosmwasm"],
     async () => {
       if (!networkId || !proposalModuleAddress) return null;
 


### PR DESCRIPTION
without this, if we query the proposals for a teritori dao and the gno query resolves first with nothing, the teritori query will return an empty list