### PR TITLE
fix(feed): portal-loop deployment

### DIFF
--- a/gno/Makefile
+++ b/gno/Makefile
@@ -1,7 +1,7 @@
-KEY = teritori
+KEY = teritori-test4-seed
 BASE = teritori
-REMOTE = https://rpc.test5.gno.land
-CHAIN_ID = test5
+REMOTE = https://rpc.gno.land
+CHAIN_ID = portal-loop
 
 .PHONY: add_social_feeds_realm add_utf16_pkg add_ujson_pkg add_flags_index_pkg add_dao_interfaces_pkg add_social_feed all
 

--- a/gno/p/jsonutil/jsonutil.gno
+++ b/gno/p/jsonutil/jsonutil.gno
@@ -7,8 +7,6 @@ import (
 
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/json"
-	"gno.land/p/demo/users"
-	rusers "gno.land/r/demo/users"
 )
 
 func UnionNode(variant string, value *json.Node) *json.Node {
@@ -128,18 +126,4 @@ func MustAddress(value *json.Node) std.Address {
 	}
 
 	return addr
-}
-
-func AddressOrNameNode(aon users.AddressOrName) *json.Node {
-	return json.StringNode("", string(aon))
-}
-
-func MustAddressOrName(value *json.Node) users.AddressOrName {
-	aon := users.AddressOrName(value.MustString())
-	address := rusers.Resolve(aon)
-	if !address.IsValid() {
-		panic("invalid address or name")
-	}
-
-	return aon
 }

--- a/gno/r/tori/messages.gno
+++ b/gno/r/tori/messages.gno
@@ -1,6 +1,7 @@
 package tori
 
 import (
+	"std"
 	"strconv"
 	"strings"
 
@@ -13,7 +14,7 @@ import (
 type ExecutableMessageMintTori struct {
 	dao_interfaces.ExecutableMessage
 
-	Recipient users.AddressOrName
+	Recipient std.Address
 	Amount    uint64
 }
 
@@ -37,13 +38,13 @@ func (msg *ExecutableMessageMintTori) String() string {
 
 func (msg *ExecutableMessageMintTori) FromJSON(ast *json.Node) {
 	obj := ast.MustObject()
-	msg.Recipient = jsonutil.MustAddressOrName(obj["recipient"])
+	msg.Recipient = jsonutil.MustAddress(obj["recipient"])
 	msg.Amount = jsonutil.MustUint64(obj["amount"])
 }
 
 func (msg *ExecutableMessageMintTori) ToJSON() *json.Node {
 	return json.ObjectNode("", map[string]*json.Node{
-		"recipient": jsonutil.AddressOrNameNode(msg.Recipient),
+		"recipient": jsonutil.AddressNode(msg.Recipient),
 		"amount":    jsonutil.Uint64Node(msg.Amount),
 	})
 }
@@ -60,7 +61,7 @@ func NewMintToriHandler() *MintToriHandler {
 
 func (h *MintToriHandler) Execute(imsg dao_interfaces.ExecutableMessage) {
 	msg := imsg.(*ExecutableMessageMintTori)
-	Mint(msg.Recipient, msg.Amount)
+	Mint(users.AddressOrName(msg.Recipient), msg.Amount)
 }
 
 func (h MintToriHandler) Type() string {
@@ -74,7 +75,7 @@ func (h *MintToriHandler) Instantiate() dao_interfaces.ExecutableMessage {
 type ExecutableMessageBurnTori struct {
 	dao_interfaces.ExecutableMessage
 
-	Target users.AddressOrName
+	Target std.Address
 	Amount uint64
 }
 
@@ -98,13 +99,13 @@ func (msg *ExecutableMessageBurnTori) String() string {
 
 func (msg *ExecutableMessageBurnTori) FromJSON(ast *json.Node) {
 	obj := ast.MustObject()
-	msg.Target = jsonutil.MustAddressOrName(obj["target"])
+	msg.Target = jsonutil.MustAddress(obj["target"])
 	msg.Amount = jsonutil.MustUint64(obj["amount"])
 }
 
 func (msg *ExecutableMessageBurnTori) ToJSON() *json.Node {
 	return json.ObjectNode("", map[string]*json.Node{
-		"target": jsonutil.AddressOrNameNode(msg.Target),
+		"target": jsonutil.AddressNode(msg.Target),
 		"amount": jsonutil.Uint64Node(msg.Amount),
 	})
 }
@@ -121,7 +122,7 @@ func NewBurnToriHandler() *BurnToriHandler {
 
 func (h *BurnToriHandler) Execute(imsg dao_interfaces.ExecutableMessage) {
 	msg := imsg.(*ExecutableMessageBurnTori)
-	Burn(msg.Target, msg.Amount)
+	Burn(users.AddressOrName(msg.Target), msg.Amount)
 }
 
 func (h BurnToriHandler) Type() string {
@@ -135,7 +136,7 @@ func (h *BurnToriHandler) Instantiate() dao_interfaces.ExecutableMessage {
 type ExecutableMessageChangeAdmin struct {
 	dao_interfaces.ExecutableMessage
 
-	NewAdmin users.AddressOrName
+	NewAdmin std.Address
 }
 
 var _ dao_interfaces.ExecutableMessage = &ExecutableMessageChangeAdmin{}
@@ -154,12 +155,12 @@ func (msg *ExecutableMessageChangeAdmin) String() string {
 
 func (msg *ExecutableMessageChangeAdmin) FromJSON(ast *json.Node) {
 	obj := ast.MustObject()
-	msg.NewAdmin = jsonutil.MustAddressOrName(obj["newAdmin"])
+	msg.NewAdmin = jsonutil.MustAddress(obj["newAdmin"])
 }
 
 func (msg *ExecutableMessageChangeAdmin) ToJSON() *json.Node {
 	return json.ObjectNode("", map[string]*json.Node{
-		"newAdmin": jsonutil.AddressOrNameNode(msg.NewAdmin),
+		"newAdmin": jsonutil.AddressNode(msg.NewAdmin),
 	})
 }
 
@@ -175,7 +176,7 @@ func NewChangeAdminHandler() *ChangeAdminHandler {
 
 func (h *ChangeAdminHandler) Execute(imsg dao_interfaces.ExecutableMessage) {
 	msg := imsg.(*ExecutableMessageChangeAdmin)
-	ChangeAdmin(msg.NewAdmin)
+	ChangeAdmin(users.AddressOrName(msg.NewAdmin))
 }
 
 func (h ChangeAdminHandler) Type() string {


### PR DESCRIPTION
The social feeds on portal loo got brought down because it's `/p/teritori/jsonutil` dependency was importing the `users` realm

I tried to fix and redeploy in this PR, deploying `jsonutils` worked but deploying the feed with `make add_social_feed` errors out with

```
❯ gnokey maketx call \                                                                                                                                                              Native
                -pkgpath "gno.land/r/teritori/social_feeds" \
                -func="CreateFeed" \
                -gas-fee="1000000ugnot" \
                -gas-wanted="5000000" \
                -remote="https://rpc.gno.land" \
                -chainid="portal-loop" \
                -broadcast \
                -args "teritori" \
                teritori-test4-seed --simulate skip
Enter password.
TX HASH:    JCaVWe0O9HM6dft5pPgDGDpwA2r312GN0F03CDavidQ=
--= Error =--
Data: internal error
Msg Traces:
    0  /Users/norman/Code/gno/tm2/pkg/crypto/keys/client/maketx.go:215 - deliver transaction failed: log:recovered: unexpected node with location gno.land/r/teritori/social_feeds/:0:0
stack:
goroutine 44 [running]:
runtime/debug.Stack()
	/opt/hostedtoolcache/go/1.22.9/x64/src/runtime/debug/stack.go:24 +0x5e
github.com/gnolang/gno/tm2/pkg/sdk.(*BaseApp).runTx.func1()
	/home/runner/work/gno/gno/tm2/pkg/sdk/baseapp.go:763 +0x205
panic({0xf01220?, 0xc006000500?})
	/opt/hostedtoolcache/go/1.22.9/x64/src/runtime/panic.go:770 +0x132
github.com/gnolang/gno/gnovm/pkg/gnolang.(*defaultStore).GetBlockNode(0x0?, {{0xc010c37940, 0x20}, {0x0, 0x0}, 0x0, 0x0})
	/home/runner/work/gno/gno/gnovm/pkg/gnolang/store.go:521 +0x1ad
github.com/gnolang/gno/gno.land/pkg/sdk/vm.(*VMKeeper).Call(_, {{0x13896b8, 0xc010084570}, 0x2, {0x1388620, 0xc029257f40}, {0x13898b0, 0xc015e0d8c0}, {0xc0054cb010, 0xb}, ...}, ...)
	/home/runner/work/gno/gno/gno.land/pkg/sdk/vm/keeper.go:422 +0x154
github.com/gnolang/gno/gno.land/pkg/sdk/vm.vmHandler.handleMsgCall({_}, {{0x13896b8, 0xc010084570}, 0x2, {0x1388620, 0xc029257f40}, {0x13898b0, 0xc015e0d8c0}, {0xc0054cb010, 0xb}, ...}, ...)
```