### PR TITLE
fix: Show the asterix in "regular" required TextInputCustom

### DIFF
--- a/packages/components/inputs/TextInputCustom.tsx
+++ b/packages/components/inputs/TextInputCustom.tsx
@@ -287,6 +287,20 @@ export const TextInputCustom = <T extends FieldValues>({
                     style={[styles.labelText, fontMedium10, labelStyle]}
                   >
                     {label}
+                    {rules?.required && (
+                      <BrandText
+                        style={[
+                          styles.labelText,
+                          fontMedium10,
+                          {
+                            color: additionalRed,
+                            marginLeft: layout.spacing_x0_5,
+                          },
+                        ]}
+                      >
+                        *
+                      </BrandText>
+                    )}
                   </BrandText>
                   <SpacerColumn size={0.5} />
                 </>


### PR DESCRIPTION
Closes https://github.com/TERITORI/teritori-dapp/issues/1458
This PR adds a behavior present on `TextInputCustom` `"labelOutside"` but missing on `"regular"`
(The red asterix next to the label for required inputs)
### Before
![image](https://github.com/user-attachments/assets/79a974fe-b0c5-4dd0-965d-204173787606)

### After
![image](https://github.com/user-attachments/assets/a30bdfcc-74e9-41ad-b66e-9f7c1ca3c657)

___

The `"labelOutside"` variant

![image](https://github.com/user-attachments/assets/60a7ba88-a600-47d0-a2ea-fcd6c632b1e8)

