### PR TITLE
fix: fullWidth for all feed screens

### DIFF
--- a/packages/screens/Feed/components/MapFeed.tsx
+++ b/packages/screens/Feed/components/MapFeed.tsx
@@ -7,17 +7,13 @@ import { MobileTitle } from "@/components/ScreenContainer/ScreenContainerMobile"
 import { Map } from "@/components/socialFeed/Map";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useMaxResolution } from "@/hooks/useMaxResolution";
-import {
-  headerHeight,
-  RESPONSIVE_BREAKPOINT_S,
-  screenContentMaxWidth,
-} from "@/utils/style/layout";
+import { headerHeight, RESPONSIVE_BREAKPOINT_S } from "@/utils/style/layout";
 
 export const MapFeed: FC<{
   consultedPostId?: string;
 }> = ({ consultedPostId }) => {
   const { height: windowHeight, width: windowWidth } = useWindowDimensions();
-  const { width, height } = useMaxResolution();
+  const { width, height } = useMaxResolution({ isLarge: true });
   const isMobile = useIsMobile();
 
   return (
@@ -29,7 +25,6 @@ export const MapFeed: FC<{
           style={{
             height: windowHeight - (headerHeight + 110),
             width: windowWidth < RESPONSIVE_BREAKPOINT_S ? windowWidth : width,
-            maxWidth: screenContentMaxWidth,
           }}
           consultedPostId={consultedPostId}
         />

--- a/packages/screens/Feed/components/MusicFeed.tsx
+++ b/packages/screens/Feed/components/MusicFeed.tsx
@@ -8,14 +8,11 @@ import { FeedMusicList } from "@/components/music/FeedMusicList";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useMaxResolution } from "@/hooks/useMaxResolution";
 import { useSelectedNetworkId } from "@/hooks/useSelectedNetwork";
-import {
-  RESPONSIVE_BREAKPOINT_S,
-  screenContentMaxWidth,
-} from "@/utils/style/layout";
+import { RESPONSIVE_BREAKPOINT_S } from "@/utils/style/layout";
 
 export const MusicFeed: FC = () => {
   const { width: windowWidth } = useWindowDimensions();
-  const { width, height } = useMaxResolution();
+  const { width, height } = useMaxResolution({ isLarge: true });
   const isMobile = useIsMobile();
   const selectedNetworkId = useSelectedNetworkId();
   return (
@@ -30,7 +27,6 @@ export const MusicFeed: FC = () => {
         style={{
           alignSelf: "center",
           width: windowWidth < RESPONSIVE_BREAKPOINT_S ? windowWidth : width,
-          maxWidth: screenContentMaxWidth,
         }}
       />
     </ScrollView>

--- a/packages/screens/Feed/components/VideosFeed.tsx
+++ b/packages/screens/Feed/components/VideosFeed.tsx
@@ -9,15 +9,12 @@ import { FeedVideosList } from "@/components/video/FeedVideosList";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useMaxResolution } from "@/hooks/useMaxResolution";
 import { useSelectedNetworkId } from "@/hooks/useSelectedNetwork";
-import {
-  RESPONSIVE_BREAKPOINT_S,
-  screenContentMaxWidth,
-} from "@/utils/style/layout";
+import { RESPONSIVE_BREAKPOINT_S } from "@/utils/style/layout";
 import { PostCategory } from "@/utils/types/feed";
 
 export const VideosFeed: FC = () => {
   const { width: windowWidth } = useWindowDimensions();
-  const { width, height } = useMaxResolution();
+  const { width, height } = useMaxResolution({ isLarge: true });
   const isMobile = useIsMobile();
   const selectedNetworkId = useSelectedNetworkId();
 
@@ -50,7 +47,6 @@ export const VideosFeed: FC = () => {
         style={{
           alignSelf: "center",
           width: windowWidth < RESPONSIVE_BREAKPOINT_S ? windowWidth : width,
-          maxWidth: screenContentMaxWidth,
         }}
       />
     </ScrollView>


### PR DESCRIPTION
Give full width for all feed screens

---
Just an example for the map

Before:
![Screenshot 2024-12-19 at 10 47 24](https://github.com/user-attachments/assets/8a664773-15c0-442c-97a6-fd27381e8466)

After:
![Screenshot 2024-12-19 at 10 47 33](https://github.com/user-attachments/assets/664e9d41-7a1e-48df-9685-3896a0af1960)

