### PR TITLE
WIP: fix: refacto react-hook-form logic for roles based organizations

### DIFF
--- a/packages/screens/Organizations/components/RolesOrg/RolesDeployerSteps.tsx
+++ b/packages/screens/Organizations/components/RolesOrg/RolesDeployerSteps.tsx
@@ -1,5 +1,7 @@
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
 import { View } from "react-native";
 
 import { RolesMembersSettingsSection } from "./RolesMembersSettingsSection";
@@ -25,8 +27,10 @@ import {
   CreateDaoFormType,
   LAUNCHING_PROCESS_STEPS,
   ROLES_BASED_ORGANIZATION_STEPS,
-  RolesMemberSettingFormType,
-  RolesSettingFormType,
+  RolesFormType,
+  RolesMembersFormType,
+  ZodRolesMembersObject,
+  ZodRolesObject,
 } from "@/utils/types/organizations";
 
 export const RolesDeployerSteps: React.FC<{
@@ -49,12 +53,41 @@ export const RolesDeployerSteps: React.FC<{
   const network = getNetwork(selectedWallet?.networkId);
   const queryClient = useQueryClient();
   const { setToast } = useFeedbacks();
+  const rolesMembersForm = useForm<RolesMembersFormType>({
+    resolver: zodResolver(ZodRolesMembersObject),
+    defaultValues: {
+      members: selectedWallet?.address
+        ? [
+            {
+              addr: selectedWallet?.address,
+              weight: "0",
+              roles: "",
+            },
+          ]
+        : [],
+    },
+  });
+  const rolesForm = useForm<RolesFormType>({
+    resolver: zodResolver(ZodRolesObject),
+    defaultValues: {
+      roles: [],
+    },
+  });
+  const membersField = useFieldArray({
+    control: rolesMembersForm.control,
+    name: "members",
+  });
+  const rolesField = useFieldArray({
+    control: rolesForm.control,
+    name: "roles",
+  });
+
   const [configureVotingFormData, setConfigureVotingFormData] =
     useState<ConfigureVotingFormType>();
-  const [rolesSettingsFormData, setRolesSettingsFormData] =
-    useState<RolesSettingFormType>();
-  const [memberSettingsFormData, setMemberSettingsFormData] =
-    useState<RolesMemberSettingFormType>();
+  // const [rolesSettingsFormData, setRolesSettingsFormData] =
+  //   useState<RolesSettingFormType>();
+  // const [memberSettingsFormData, setMemberSettingsFormData] =
+  //   useState<RolesMemberSettingFormType>();
 
   const createDaoContract = async (): Promise<boolean> => {
     try {
@@ -62,20 +95,18 @@ export const RolesDeployerSteps: React.FC<{
         case NetworkKind.Gno: {
           const name = organizationData?.associatedHandle!;
           const roles =
-            rolesSettingsFormData?.roles?.map((role) => ({
+            rolesField?.fields?.map((role) => ({
               name: role.name.trim(),
               color: role.color,
               resources: role.resources,
             })) || [];
-          const initialMembers = (memberSettingsFormData?.members || []).map(
-            (member) => ({
-              address: member.addr,
-              weight: parseInt(member.weight, 10),
-              roles: member.roles
-                ? member.roles.split(",").map((role) => role.trim())
-                : [],
-            }),
-          );
+          const initialMembers = (membersField?.fields || []).map((member) => ({
+            address: member.addr,
+            weight: parseInt(member.weight, 10),
+            roles: member.roles
+              ? member.roles.split(",").map((role) => role.trim())
+              : [],
+          }));
           const pkgPath = await adenaDeployGnoDAO(
             network.id,
             selectedWallet?.address!,
@@ -113,7 +144,7 @@ export const RolesDeployerSteps: React.FC<{
             network.cwAdminFactoryContractAddress!;
           const walletAddress = selectedWallet.address;
 
-          if (!memberSettingsFormData) return false;
+          if (!membersField.fields) return false;
           const params: CreateDaoMemberBasedParams = {
             networkId,
             sender: walletAddress,
@@ -127,7 +158,7 @@ export const RolesDeployerSteps: React.FC<{
             description: organizationData.organizationDescription,
             tns: organizationData.associatedHandle,
             imageUrl: organizationData.imageUrl,
-            members: memberSettingsFormData.members.map((value) => ({
+            members: membersField.fields.map((value) => ({
               addr: value.addr,
               weight: parseInt(value.weight, 10),
             })),
@@ -184,13 +215,11 @@ export const RolesDeployerSteps: React.FC<{
     setCurrentStep(2);
   };
 
-  const onSubmitRolesSettings = (data: RolesSettingFormType) => {
-    setRolesSettingsFormData(data);
+  const onSubmitRolesSettings = () => {
     setCurrentStep(3);
   };
 
-  const onSubmitMemberSettings = (data: RolesMemberSettingFormType) => {
-    setMemberSettingsFormData(data);
+  const onSubmitMemberSettings = () => {
     setCurrentStep(4);
   };
 
@@ -215,8 +244,6 @@ export const RolesDeployerSteps: React.FC<{
     );
     setOrganizationData(undefined);
     setConfigureVotingFormData(undefined);
-    setRolesSettingsFormData(undefined);
-    setMemberSettingsFormData(undefined);
     setCurrentStep(0);
     setDAOAddress("");
     setLaunchingStep(0);
@@ -239,14 +266,25 @@ export const RolesDeployerSteps: React.FC<{
           currentStep === 2 ? { display: "flex", flex: 1 } : { display: "none" }
         }
       >
-        <RolesSettingsSection onSubmit={onSubmitRolesSettings} />
+        <RolesSettingsSection
+          remove={rolesField.remove}
+          append={rolesField.append}
+          roles={rolesField.fields}
+          handleSubmit={rolesForm.handleSubmit(onSubmitRolesSettings)}
+        />
       </View>
       <View
         style={
           currentStep === 3 ? { display: "flex", flex: 1 } : { display: "none" }
         }
       >
-        <RolesMembersSettingsSection onSubmit={onSubmitMemberSettings} />
+        <RolesMembersSettingsSection
+          members={membersField.fields}
+          append={membersField.append}
+          control={rolesMembersForm.control}
+          remove={membersField.remove}
+          handleSubmit={rolesMembersForm.handleSubmit(onSubmitMemberSettings)}
+        />
       </View>
       <View
         style={
@@ -256,8 +294,8 @@ export const RolesDeployerSteps: React.FC<{
         <RolesReviewInformationSection
           organizationData={organizationData}
           votingSettingData={configureVotingFormData}
-          rolesSettingData={rolesSettingsFormData}
-          memberSettingData={memberSettingsFormData}
+          rolesSettingData={rolesField.fields}
+          memberSettingData={membersField.fields}
           onSubmit={onStartLaunchingProcess}
         />
       </View>

--- a/packages/screens/Organizations/components/RolesOrg/RolesMembersSettingsSection.tsx
+++ b/packages/screens/Organizations/components/RolesOrg/RolesMembersSettingsSection.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
+import React from "react";
+import { Control, UseFieldArrayAppend } from "react-hook-form";
 import { Pressable, ScrollView, View, ViewStyle } from "react-native";
+import { z } from "zod";
 
 import trashSVG from "../../../../../assets/icons/trash.svg";
 import walletInputSVG from "../../../../../assets/icons/wallet-input.svg";
-import useSelectedWallet from "../../../../hooks/useSelectedWallet";
 
 import { BrandText } from "@/components/BrandText";
 import { SVG } from "@/components/SVG";
@@ -18,50 +18,31 @@ import { fontSemibold28 } from "@/utils/style/fonts";
 import { layout } from "@/utils/style/layout";
 import {
   ROLES_BASED_ORGANIZATION_STEPS,
-  RolesMemberSettingFormType,
+  RolesMembersFormType,
+  ZodRolesMemberObject,
 } from "@/utils/types/organizations";
 
 interface RolesMembersSettingsSectionProps {
-  onSubmit: (form: RolesMemberSettingFormType) => void;
+  members: z.infer<typeof ZodRolesMemberObject>[];
+  append: UseFieldArrayAppend<RolesMembersFormType>;
+  control: Control<RolesMembersFormType>;
+  remove: (index?: number | number[] | undefined) => void;
+  handleSubmit: () => void;
 }
 
 export const RolesMembersSettingsSection: React.FC<
   RolesMembersSettingsSectionProps
-> = ({ onSubmit }) => {
-  const { handleSubmit, control, resetField, unregister } =
-    useForm<RolesMemberSettingFormType>();
-
-  // this effect put the selected wallet address in the first field only on initial load
-  const selectedWallet = useSelectedWallet();
-  const [initialReset, setInitialReset] = useState(false);
-  useEffect(() => {
-    if (initialReset) {
-      return;
-    }
-    if (!selectedWallet?.address) {
-      return;
-    }
-    resetField("members.0.addr", {
-      defaultValue: selectedWallet?.address,
-    });
-    setInitialReset(true);
-  }, [selectedWallet?.address, resetField, initialReset]);
-
-  const [addressIndexes, setAddressIndexes] = useState<number[]>([0]);
-
-  // functions
-  const removeAddressField = (id: number, index: number) => {
-    unregister(`members.${index}.addr`);
-    unregister(`members.${index}.weight`);
-    unregister(`members.${index}.roles`);
-    if (addressIndexes.length > 1) {
-      const copyIndex = [...addressIndexes].filter((i) => i !== id);
-      setAddressIndexes(copyIndex);
-    }
+> = ({ handleSubmit, append, remove, members, control }) => {
+  const removeAddressField = (index: number) => {
+    remove(index);
   };
 
   const addAddressField = () => {
-    setAddressIndexes([...addressIndexes, Math.floor(Math.random() * 200000)]);
+    append({
+      addr: "",
+      weight: "",
+      roles: "",
+    });
   };
 
   return (
@@ -70,10 +51,10 @@ export const RolesMembersSettingsSection: React.FC<
         <BrandText style={fontSemibold28}>Members</BrandText>
         <SpacerColumn size={2.5} />
 
-        {addressIndexes.map((id, index) => (
-          <View style={inputContainerCStyle} key={id.toString()}>
+        {members.map((member, index) => (
+          <View style={inputContainerCStyle} key={member.addr}>
             <View style={leftInputCStyle}>
-              <TextInputCustom<RolesMemberSettingFormType>
+              <TextInputCustom<RolesMembersFormType>
                 name={`members.${index}.addr`}
                 noBrokenCorners
                 label="Member Address"
@@ -85,7 +66,7 @@ export const RolesMembersSettingsSection: React.FC<
               >
                 <Pressable
                   style={trashContainerCStyle}
-                  onPress={() => removeAddressField(id, index)}
+                  onPress={() => removeAddressField(index)}
                 >
                   <SVG source={trashSVG} width={12} height={12} />
                 </Pressable>
@@ -93,7 +74,7 @@ export const RolesMembersSettingsSection: React.FC<
             </View>
             <SpacerRow size={2.5} />
             <View style={rightInputCStyle}>
-              <TextInputCustom<RolesMemberSettingFormType>
+              <TextInputCustom<RolesMembersFormType>
                 name={`members.${index}.weight`}
                 noBrokenCorners
                 label="Weight"
@@ -106,7 +87,7 @@ export const RolesMembersSettingsSection: React.FC<
             </View>
             <SpacerRow size={2.5} />
             <View style={rightInputCStyle}>
-              <TextInputCustom<RolesMemberSettingFormType>
+              <TextInputCustom<RolesMembersFormType>
                 name={`members.${index}.roles`}
                 noBrokenCorners
                 label="Roles - separate with a comma"
@@ -125,7 +106,7 @@ export const RolesMembersSettingsSection: React.FC<
         <PrimaryButton
           size="M"
           text={`Next: ${ROLES_BASED_ORGANIZATION_STEPS[4]}`}
-          onPress={handleSubmit(onSubmit)}
+          onPress={handleSubmit}
           testID="member-settings-next"
         />
       </View>

--- a/packages/screens/Organizations/components/RolesOrg/RolesReviewInformationSection.tsx
+++ b/packages/screens/Organizations/components/RolesOrg/RolesReviewInformationSection.tsx
@@ -7,6 +7,7 @@ import {
   View,
   ViewStyle,
 } from "react-native";
+import { z } from "zod";
 
 import { ReviewCollapsable } from "./../ReviewCollapsable";
 import { ReviewCollapsableItem } from "./../ReviewCollapsableItem";
@@ -24,17 +25,17 @@ import { tinyAddress } from "@/utils/text";
 import {
   ConfigureVotingFormType,
   CreateDaoFormType,
-  RolesMemberSettingFormType,
-  RolesSettingFormType,
   TokenSettingFormType,
+  ZodRoleObject,
+  ZodRolesMemberObject,
 } from "@/utils/types/organizations";
 
 interface RolesReviewInformationSectionProps {
   organizationData?: CreateDaoFormType;
   votingSettingData?: ConfigureVotingFormType;
   tokenSettingData?: TokenSettingFormType;
-  memberSettingData?: RolesMemberSettingFormType;
-  rolesSettingData?: RolesSettingFormType;
+  memberSettingData?: z.infer<typeof ZodRolesMemberObject>[];
+  rolesSettingData?: z.infer<typeof ZodRoleObject>[];
   onSubmit: () => void;
 }
 
@@ -164,7 +165,7 @@ export const RolesReviewInformationSection: React.FC<
 
       <SpacerColumn size={2.5} />
       <ReviewCollapsable title="Roles settings">
-        {rolesSettingData?.roles?.map((role, index) => (
+        {rolesSettingData?.map((role, index) => (
           <View key={role.name} style={fillCStyle}>
             <ReviewCollapsableItem
               title={`ROLE #${index + 1}`}
@@ -174,7 +175,7 @@ export const RolesReviewInformationSection: React.FC<
                 </BrandText>
               )}
             />
-            {rolesSettingData?.roles.length !== index + 1 && (
+            {rolesSettingData?.length !== index + 1 && (
               <SpacerColumn size={1} />
             )}
           </View>
@@ -183,7 +184,7 @@ export const RolesReviewInformationSection: React.FC<
       <SpacerColumn size={2.5} />
 
       <ReviewCollapsable title="Member settings">
-        {memberSettingData?.members.map((member, index) => (
+        {memberSettingData?.map((member, index) => (
           <View key={member.addr} style={fillCStyle}>
             <ReviewCollapsableItem
               title={`MEMBER #${index + 1}`}

--- a/packages/screens/Organizations/components/RolesOrg/RolesSettingsSection.tsx
+++ b/packages/screens/Organizations/components/RolesOrg/RolesSettingsSection.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { useForm } from "react-hook-form";
+import { UseFieldArrayAppend } from "react-hook-form";
 import { Pressable, View } from "react-native";
 import { FlatList, ScrollView } from "react-native-gesture-handler";
+import { z } from "zod";
 
 import { RolesModalCreateRole } from "./RolesModalCreateRole";
 import trashSVG from "../../../../../assets/icons/trash.svg";
@@ -22,62 +23,39 @@ import { fontSemibold28 } from "@/utils/style/fonts";
 import { layout, screenContentMaxWidthLarge } from "@/utils/style/layout";
 import {
   ROLES_BASED_ORGANIZATION_STEPS,
-  RolesSettingFormType,
+  RolesFormType,
+  ZodRoleObject,
 } from "@/utils/types/organizations";
 
 interface RolesSettingsSectionProps {
-  onSubmit: (form: RolesSettingFormType) => void;
+  roles: z.infer<typeof ZodRoleObject>[];
+  remove: (index?: number | number[] | undefined) => void;
+  append: UseFieldArrayAppend<RolesFormType>;
+  handleSubmit: () => void;
 }
 
 export const RolesSettingsSection: React.FC<RolesSettingsSectionProps> = ({
-  onSubmit,
+  roles,
+  remove,
+  append,
+  handleSubmit,
 }) => {
-  const {
-    handleSubmit,
-    control,
-    unregister,
-    register,
-    setValue,
-    resetField,
-    getValues,
-  } = useForm<RolesSettingFormType>();
   const [modalVisible, setModalVisible] = useState(false);
-  const [rolesIndexes, setRolesIndexes] = useState<number[]>([]);
-  const [resources, setResources] =
-    useState<{ name: string; resources: string[]; value: boolean }[]>(
-      fakeResources,
-    );
 
-  const removeRoleField = (id: number, index: number) => {
-    unregister(`roles.${index}.name`);
-    unregister(`roles.${index}.color`);
-    unregister(`roles.${index}.resources`);
-    if (rolesIndexes.length > 0) {
-      const copyIndex = [...rolesIndexes].filter((i) => i !== id);
-      setRolesIndexes(copyIndex);
-    }
-  };
-
-  const resetModal = () => {
-    resetField(`roles.${rolesIndexes.length}.name`);
-    resetField(`roles.${rolesIndexes.length}.color`);
-    resetField(`roles.${rolesIndexes.length}.resources`);
+  const removeRoleField = (index: number) => {
+    remove(index);
   };
 
   const onOpenModal = () => {
-    resetModal();
-    setResources(fakeResources.map((r) => ({ ...r, value: false })));
     setModalVisible(true);
   };
 
-  const addRoleField = () => {
-    register(`roles.${rolesIndexes.length}.resources`);
-    const selectedResources = resources
-      .filter((r) => r.value)
-      .flatMap((r) => r.resources);
-    setValue(`roles.${rolesIndexes.length}.resources`, selectedResources);
-    console.log(`Selected resources: ${selectedResources}`);
-    setRolesIndexes([...rolesIndexes, Math.floor(Math.random() * 200000)]);
+  const addRoleField = (name: string, color: string, resources: string[]) => {
+    append({
+      name,
+      color,
+      resources,
+    });
     setModalVisible(false);
   };
 
@@ -85,21 +63,11 @@ export const RolesSettingsSection: React.FC<RolesSettingsSectionProps> = ({
     setModalVisible(false);
   };
 
-  const onCheckboxChange = (index: number) => {
-    const copyResources = [...resources];
-    copyResources[index].value = !copyResources[index].value;
-    setResources(copyResources);
-  };
-
   return (
     <View style={{ flex: 1 }}>
       <RolesModalCreateRole
         modalVisible={modalVisible}
-        rolesIndexes={rolesIndexes}
-        resources={resources}
-        control={control}
         onCloseModal={onCloseModal}
-        onCheckboxChange={onCheckboxChange}
         addRoleField={addRoleField}
       />
       <ScrollView
@@ -123,16 +91,16 @@ export const RolesSettingsSection: React.FC<RolesSettingsSectionProps> = ({
           <TableWrapper horizontalScrollBreakpoint={800}>
             <TableHeader columns={columns} />
             <FlatList
-              data={rolesIndexes}
+              data={roles}
               renderItem={({ item, index }) => {
-                const role = getValues(`roles.${index}`);
+                const role = item;
 
                 if (!role) {
                   return null;
                 }
 
                 return (
-                  <View key={item} style={{ flex: 1 }}>
+                  <View key={item.name} style={{ flex: 1 }}>
                     <RoleTableRow
                       role={{
                         name: role.name || "undefined",
@@ -140,7 +108,6 @@ export const RolesSettingsSection: React.FC<RolesSettingsSectionProps> = ({
                         resources: role.resources,
                       }}
                       removeRoleField={removeRoleField}
-                      id={item}
                       index={index}
                     />
                     <SpacerColumn size={1} />
@@ -167,7 +134,7 @@ export const RolesSettingsSection: React.FC<RolesSettingsSectionProps> = ({
         <PrimaryButton
           size="M"
           text={`Next: ${ROLES_BASED_ORGANIZATION_STEPS[3]}`}
-          onPress={handleSubmit(onSubmit)}
+          onPress={handleSubmit}
           testID="roles-settings-next"
         />
       </View>
@@ -177,10 +144,9 @@ export const RolesSettingsSection: React.FC<RolesSettingsSectionProps> = ({
 
 const RoleTableRow: React.FC<{
   role: { name: string; color: string; resources: string[] | undefined };
-  removeRoleField: (id: number, index: number) => void;
-  id: number;
+  removeRoleField: (index: number) => void;
   index: number;
-}> = ({ role, removeRoleField, id, index }) => {
+}> = ({ role, removeRoleField, index }) => {
   return (
     <TableRow>
       <TableTextCell
@@ -216,7 +182,7 @@ const RoleTableRow: React.FC<{
         <View>
           <Pressable
             onPress={() => {
-              removeRoleField(id, index);
+              removeRoleField(index);
             }}
           >
             <SVG source={trashSVG} width={32} height={32} style={{}} />
@@ -249,47 +215,3 @@ const columns: TableColumns = {
     minWidth: 30,
   },
 };
-
-// TODO: Create a hook to get all the resources
-const fakeResources = [
-  {
-    name: "Organizations",
-    resources: [],
-    value: false,
-  },
-  {
-    name: "Social Feed",
-    resources: ["gno.land/r/teritori/social_feeds.CreatePost"],
-    value: false,
-  },
-  {
-    name: "Marketplace",
-    resources: [],
-    value: false,
-  },
-  {
-    name: "Launchpad NFT",
-    resources: [],
-    value: false,
-  },
-  {
-    name: "Launchpad ERC20",
-    resources: [],
-    value: false,
-  },
-  {
-    name: "Name Service",
-    resources: [],
-    value: false,
-  },
-  {
-    name: "Multisig Wallet",
-    resources: [],
-    value: false,
-  },
-  {
-    name: "Projects",
-    resources: [],
-    value: false,
-  },
-];

--- a/packages/utils/types/organizations.ts
+++ b/packages/utils/types/organizations.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { NSAvailability } from "./tns";
 
 export enum DaoType {
@@ -26,6 +28,35 @@ export type ConfigureVotingFormType = {
   hours: string;
   minutes: string;
 };
+
+export const ZodRoleObject = z.object({
+  name: z.string().trim().min(1),
+  color: z.string().trim().min(1),
+  resources: z.array(z.string().optional()).optional(),
+});
+export const ZodRolesMemberObject = z.object({
+  addr: z.string().trim().min(1),
+  weight: z.string().trim().min(1),
+  // TODO: change it to an array
+  roles: z.string(),
+});
+export const ZodRolesObject = z.object({
+  roles: z.array(ZodRoleObject),
+});
+export const ZodRolesMembersObject = z.object({
+  members: z.array(ZodRolesMemberObject),
+});
+const ZodRolesConfigObject = z.object({
+  supportPercent: z.number(),
+  minimumApprovalPercent: z.number(),
+  days: z.string().trim(),
+  hours: z.string().trim(),
+  minutes: z.string().trim(),
+});
+export type RolesConfigFormType = z.infer<typeof ZodRolesConfigObject>;
+export type RolesMembersFormType = z.infer<typeof ZodRolesMembersObject>;
+export type RolesFormType = z.infer<typeof ZodRolesObject>;
+export type RoleFormType = z.infer<typeof ZodRoleObject>;
 
 export type LaunchingProcessStepType = {
   title: string;


### PR DESCRIPTION
Start a refacto about react-hook-form logic for roles based organizations.
The goal is to understand better the react-hook-form flow because it's a lot of abstractions. You can give your opinion if you find it more appropriate and understandable.

TODO:
- [ ] Re-check naming, especially for zod objects and types
- [ ] Re-check logic
- [ ] Test the process a lot

Can't refacto `ConfigureVotingFormData` and `OrganizationData` because it's generic between all organizations, but could be cool to adapt it.