### PR TITLE
fix(articles): Remove max width in article creation

### DIFF
--- a/packages/screens/FeedNewArticle/FeedNewArticleScreen.tsx
+++ b/packages/screens/FeedNewArticle/FeedNewArticleScreen.tsx
@@ -357,7 +357,6 @@ export const FeedNewArticleScreen: ScreenFC<"FeedNewArticle"> = () => {
         <View
           style={{
             width: isSmallScreen ? windowWidth : width,
-            maxWidth: screenContentMaxWidth,
             alignSelf: "center",
           }}
         >

--- a/packages/screens/FeedNewArticle/components/ArticleContentEditor/ArticleContentEditor.tsx
+++ b/packages/screens/FeedNewArticle/components/ArticleContentEditor/ArticleContentEditor.tsx
@@ -19,7 +19,6 @@ import {
   renderHtmlTagStyles,
   renderHtmlDomVisitors,
 } from "@/utils/feed/markdown";
-import { ARTICLE_MAX_WIDTH } from "@/utils/social-feed";
 import {
   neutral00,
   neutral33,
@@ -81,7 +80,6 @@ export const ArticleContentEditor: FC<Props> = ({ width }) => {
         style={{
           flexDirection: "row",
           width: windowWidth < RESPONSIVE_BREAKPOINT_S ? "100%" : width,
-          maxWidth: ARTICLE_MAX_WIDTH + 16 * 2,
           height: editionAndPreviewHeight,
         }}
       >


### PR DESCRIPTION
To complete the work of @clegirar about max screens max width, I adjusted the max width in the Article creation's screen.

You can compare:

Before: https://app.teritori.com/feed/new
After: _TODO_

After:
![image](https://github.com/user-attachments/assets/941858eb-f06f-4b9b-8a79-800511b4c9de)
