### PR TITLE
fix(feed): Remove max width for posts view

### DIFF
--- a/packages/screens/FeedPostView/components/FeedPostArticleMarkdownView.tsx
+++ b/packages/screens/FeedPostView/components/FeedPostArticleMarkdownView.tsx
@@ -44,11 +44,7 @@ import {
   SOCIAl_CARD_BORDER_RADIUS,
 } from "@/utils/social-feed";
 import { neutral33 } from "@/utils/style/colors";
-import {
-  layout,
-  RESPONSIVE_BREAKPOINT_S,
-  screenContentMaxWidth,
-} from "@/utils/style/layout";
+import { layout, RESPONSIVE_BREAKPOINT_S } from "@/utils/style/layout";
 import { tinyAddress } from "@/utils/text";
 import {
   OnPressReplyType,
@@ -69,6 +65,8 @@ export const FeedPostArticleMarkdownView: FC<{
   const navigation = useAppNavigation();
   const { width: windowWidth } = useWindowDimensions();
   const { width } = useMaxResolution();
+  const isSmallScreen = windowWidth < RESPONSIVE_BREAKPOINT_S;
+  const contentWidth = isSmallScreen ? windowWidth : width;
   const isMobile = useIsMobile();
   const [parentOffsetValue, setParentOffsetValue] = useState(0);
 
@@ -192,7 +190,10 @@ export const FeedPostArticleMarkdownView: FC<{
     >
       <Animated.ScrollView
         ref={aref}
-        contentContainerStyle={contentContainerCStyle}
+        contentContainerStyle={[
+          contentContainerCStyle,
+          { width: contentWidth },
+        ]}
         onScroll={scrollHandler}
         scrollEventThrottle={1}
       >
@@ -200,8 +201,7 @@ export const FeedPostArticleMarkdownView: FC<{
         {isMobile && <MobileTitle title={headerLabel.toUpperCase()} />}
         <View
           style={{
-            width: windowWidth < RESPONSIVE_BREAKPOINT_S ? windowWidth : width,
-            maxWidth: screenContentMaxWidth,
+            width: "100%",
             alignItems: "center",
             paddingVertical: layout.spacing_x2,
           }}
@@ -220,10 +220,7 @@ export const FeedPostArticleMarkdownView: FC<{
               maxWidth: ARTICLE_MAX_WIDTH + contentPaddingHorizontal * 2,
               borderBottomWidth: 1,
               borderBottomColor: neutral33,
-              borderRadius:
-                windowWidth < RESPONSIVE_BREAKPOINT_S
-                  ? 0
-                  : SOCIAl_CARD_BORDER_RADIUS,
+              borderRadius: isSmallScreen ? 0 : SOCIAl_CARD_BORDER_RADIUS,
               paddingHorizontal: contentPaddingHorizontal,
               paddingBottom: layout.spacing_x2,
             }}

--- a/packages/screens/FeedPostView/components/FeedPostArticleView.tsx
+++ b/packages/screens/FeedPostView/components/FeedPostArticleView.tsx
@@ -36,17 +36,12 @@ import { zodTryParseJSON } from "@/utils/sanitize";
 import {
   ARTICLE_COVER_IMAGE_MAX_HEIGHT,
   ARTICLE_COVER_IMAGE_RATIO,
-  ARTICLE_MAX_WIDTH,
   DEFAULT_USERNAME,
   LINES_HORIZONTAL_SPACE,
   SOCIAl_CARD_BORDER_RADIUS,
 } from "@/utils/social-feed";
 import { neutral33 } from "@/utils/style/colors";
-import {
-  layout,
-  RESPONSIVE_BREAKPOINT_S,
-  screenContentMaxWidth,
-} from "@/utils/style/layout";
+import { layout, RESPONSIVE_BREAKPOINT_S } from "@/utils/style/layout";
 import { tinyAddress } from "@/utils/text";
 import {
   OnPressReplyType,
@@ -66,6 +61,8 @@ export const FeedPostArticleView: FC<{
   const navigation = useAppNavigation();
   const { width: windowWidth } = useWindowDimensions();
   const { width } = useMaxResolution();
+  const isSmallScreen = windowWidth < RESPONSIVE_BREAKPOINT_S;
+  const contentWidth = isSmallScreen ? windowWidth : width;
   const isMobile = useIsMobile();
   const [parentOffsetValue, setParentOffsetValue] = useState(0);
 
@@ -197,7 +194,10 @@ export const FeedPostArticleView: FC<{
     >
       <Animated.ScrollView
         ref={aref}
-        contentContainerStyle={contentContainerCStyle}
+        contentContainerStyle={[
+          contentContainerCStyle,
+          { width: contentWidth },
+        ]}
         onScroll={scrollHandler}
         scrollEventThrottle={1}
       >
@@ -205,8 +205,7 @@ export const FeedPostArticleView: FC<{
         {isMobile && <MobileTitle title={headerLabel.toUpperCase()} />}
         <View
           style={{
-            width: windowWidth < RESPONSIVE_BREAKPOINT_S ? windowWidth : width,
-            maxWidth: screenContentMaxWidth,
+            width: "100%",
             alignItems: "center",
             paddingVertical: layout.spacing_x2,
           }}
@@ -222,13 +221,9 @@ export const FeedPostArticleView: FC<{
             }}
             style={{
               width: "100%",
-              maxWidth: ARTICLE_MAX_WIDTH + contentPaddingHorizontal * 2,
               borderBottomWidth: 1,
               borderBottomColor: neutral33,
-              borderRadius:
-                windowWidth < RESPONSIVE_BREAKPOINT_S
-                  ? 0
-                  : SOCIAl_CARD_BORDER_RADIUS,
+              borderRadius: isSmallScreen ? 0 : SOCIAl_CARD_BORDER_RADIUS,
               paddingHorizontal: contentPaddingHorizontal,
               paddingBottom: layout.spacing_x2,
             }}
@@ -243,7 +238,6 @@ export const FeedPostArticleView: FC<{
                     style={{
                       width: "100%",
                       aspectRatio: ARTICLE_COVER_IMAGE_RATIO,
-                      // height: ARTICLE_COVER_IMAGE_MAX_HEIGHT/1.6,
                       maxHeight: ARTICLE_COVER_IMAGE_MAX_HEIGHT,
                     }}
                   />

--- a/packages/screens/FeedPostView/components/FeedPostDefaultView.tsx
+++ b/packages/screens/FeedPostView/components/FeedPostDefaultView.tsx
@@ -29,11 +29,7 @@ import { useMaxResolution } from "@/hooks/useMaxResolution";
 import { useNSUserInfo } from "@/hooks/useNSUserInfo";
 import { parseUserId } from "@/networks";
 import { DEFAULT_USERNAME, LINES_HORIZONTAL_SPACE } from "@/utils/social-feed";
-import {
-  layout,
-  RESPONSIVE_BREAKPOINT_S,
-  screenContentMaxWidth,
-} from "@/utils/style/layout";
+import { layout, RESPONSIVE_BREAKPOINT_S } from "@/utils/style/layout";
 import { tinyAddress } from "@/utils/text";
 import {
   OnPressReplyType,
@@ -50,6 +46,8 @@ export const FeedPostDefaultView: FC<{
 
   const { width: windowWidth } = useWindowDimensions();
   const { width } = useMaxResolution();
+  const isSmallScreen = windowWidth < RESPONSIVE_BREAKPOINT_S;
+  const contentWidth = isSmallScreen ? windowWidth : width;
   const isMobile = useIsMobile();
   const [parentOffsetValue, setParentOffsetValue] = useState(0);
 
@@ -163,7 +161,10 @@ export const FeedPostDefaultView: FC<{
     >
       <Animated.ScrollView
         ref={aref}
-        contentContainerStyle={contentContainerCStyle}
+        contentContainerStyle={[
+          contentContainerCStyle,
+          { width: contentWidth },
+        ]}
         onScroll={scrollHandler}
         scrollEventThrottle={1}
       >
@@ -171,8 +172,7 @@ export const FeedPostDefaultView: FC<{
         {isMobile && <MobileTitle title={headerLabel.toUpperCase()} />}
         <View
           style={{
-            width: windowWidth < RESPONSIVE_BREAKPOINT_S ? windowWidth : width,
-            maxWidth: screenContentMaxWidth,
+            width: "100%",
             alignItems: "center",
             paddingVertical: layout.spacing_x2,
           }}
@@ -192,7 +192,7 @@ export const FeedPostDefaultView: FC<{
               <SocialThreadCard
                 refetchFeed={refetchPost}
                 style={
-                  windowWidth < RESPONSIVE_BREAKPOINT_S && {
+                  isSmallScreen && {
                     borderRadius: 0,
                     borderLeftWidth: 0,
                     borderRightWidth: 0,
@@ -256,44 +256,51 @@ export const FeedPostDefaultView: FC<{
       )}
 
       {/*========== Refresh button and Comment button mobile */}
-      {isMobile ? (
-        <>
-          <SpacerColumn size={2} />
-          <View
-            style={{
-              flexDirection: "row",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            <CreateShortPostButton
-              label="Create Comment"
-              onPress={() => setCreateModalVisible(true)}
-            />
-            <SpacerRow size={1.5} />
-            <RefreshButton
-              isRefreshing={isLoadingSharedValue}
-              onPress={() => {
-                refetchComments();
+      <View
+        style={{
+          width: contentWidth,
+          alignSelf: "center",
+        }}
+      >
+        {isMobile ? (
+          <>
+            <SpacerColumn size={2} />
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "center",
               }}
-            />
-          </View>
-          <SpacerColumn size={2} />
-        </>
-      ) : (
-        <NewsFeedInput
-          style={{ alignSelf: "center" }}
-          ref={feedInputRef}
-          type="comment"
-          replyTo={replyTo}
-          parentId={post.id}
-          onSubmitInProgress={handleSubmitInProgress}
-          onSubmitSuccess={() => {
-            setReplyTo(undefined);
-            refetchComments();
-          }}
-        />
-      )}
+            >
+              <CreateShortPostButton
+                label="Create Comment"
+                onPress={() => setCreateModalVisible(true)}
+              />
+              <SpacerRow size={1.5} />
+              <RefreshButton
+                isRefreshing={isLoadingSharedValue}
+                onPress={() => {
+                  refetchComments();
+                }}
+              />
+            </View>
+            <SpacerColumn size={2} />
+          </>
+        ) : (
+          <NewsFeedInput
+            style={{ alignSelf: "center" }}
+            ref={feedInputRef}
+            type="comment"
+            replyTo={replyTo}
+            parentId={post.id}
+            onSubmitInProgress={handleSubmitInProgress}
+            onSubmitSuccess={() => {
+              setReplyTo(undefined);
+              refetchComments();
+            }}
+          />
+        )}
+      </View>
 
       <CreateShortPostModal
         label="Create a Comment"

--- a/packages/screens/FeedPostView/components/FeedPostVideoView.tsx
+++ b/packages/screens/FeedPostView/components/FeedPostVideoView.tsx
@@ -60,7 +60,6 @@ import {
   ZodSocialFeedVideoMetadata,
 } from "@/utils/types/feed";
 
-const POST_VIDEO_MAX_WIDTH = 960;
 const INPUT_MIN_HEIGHT = 20;
 const INPUT_MAX_HEIGHT = 400;
 
@@ -265,7 +264,6 @@ export const FeedPostVideoView: FC<{
           <View
             style={{
               flex: 1,
-              maxWidth: POST_VIDEO_MAX_WIDTH,
             }}
           >
             <View


### PR DESCRIPTION
To complete the work of @clegirar about max screens max width, I adjusted the max width in the Posts consultation's screen.

### You can compare:

#### Before:
- Video Post: https://app.teritori.com/feed/post/testori-6d2b87e4-df22-4edb-8963-c0f7955296d4
- Default post: https://app.teritori.com/feed/post/tori-86d814a4-e558-41fc-bbb3-ec1aed875270
- Article post: https://app.teritori.com/feed/post/tori-94b9ce64-e61c-4313-add8-4ec4e0291a3e

#### After: 
_TODO: Add deploy preview URLs_